### PR TITLE
fix: describe to work with parameterized SQL queries

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -57,6 +57,7 @@ class FakeSnowflakeCursor:
         self._duck_conn = duck_conn
         self._use_dict_result = use_dict_result
         self._last_sql = None
+        self._last_params = None
 
     def __enter__(self) -> Self:
         return self
@@ -91,7 +92,7 @@ class FakeSnowflakeCursor:
 
             # match database and schema used on the main connection
             cur.execute(f"SET SCHEMA = '{self._conn.database}.{self._conn.schema}'")
-            cur.execute(f"DESCRIBE {self._last_sql}")
+            cur.execute(f"DESCRIBE {self._last_sql}", self._last_params)
             meta = FakeSnowflakeCursor._describe_as_result_metadata(cur.fetchall())  # noqa: SLF001
 
         return meta  # type: ignore see https://github.com/duckdb/duckdb/issues/7816
@@ -150,6 +151,7 @@ class FakeSnowflakeCursor:
         if cmd != "COMMENT TABLE":
             try:
                 self._last_sql = sql
+                self._last_params = params
                 self._duck_conn.execute(sql, params)
             except duckdb.BinderException as e:
                 msg = e.args[0]

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -218,6 +218,50 @@ def test_describe(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.description == expected_metadata
 
 
+def test_describe_with_params(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute(
+        """
+        create table customers (
+            ID int, CNAME varchar, AMOUNT decimal(10,2), PCT real, ACTIVE boolean,
+            UPDATE_AT timestamp, UPDATE_AT_NTZ timestamp_ntz(9), INSERTIONDATE DATE
+        )
+        """
+    )
+    # fmt: off
+    expected_metadata = [
+        snowflake.connector.cursor.ResultMetadata(
+            name="ID", type_code=0, display_size=None, internal_size=None, precision=38, scale=0, is_nullable=True                  # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name="CNAME", type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True,     # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name="AMOUNT", type_code=0, display_size=None, internal_size=None, precision=10, scale=2, is_nullable=True,             # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name="PCT", type_code=1, display_size=None, internal_size=None, precision=None, scale=None, is_nullable=True,           # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name="ACTIVE", type_code=13, display_size=None, internal_size=None, precision=None, scale=None, is_nullable=True,       # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name='UPDATE_AT', type_code=8, display_size=None, internal_size=None, precision=0, scale=9, is_nullable=True            # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name='UPDATE_AT_NTZ', type_code=8, display_size=None, internal_size=None, precision=0, scale=9, is_nullable=True        # type: ignore # noqa: E501
+        ),
+        snowflake.connector.cursor.ResultMetadata(
+            name='INSERTIONDATE', type_code=3, display_size=None, internal_size=None, precision=None, scale=None, is_nullable=True  # type: ignore # noqa: E501
+        ),
+    ]
+    # fmt: on
+
+    assert cur.describe("select * from customers where id = ?", (1,)) == expected_metadata
+
+    cur.execute("select * from customers where id = ?", (1,))
+    assert cur.description == expected_metadata
+
+
 def test_executemany(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("create table customers (ID int, FIRST_NAME varchar, LAST_NAME varchar)")
 


### PR DESCRIPTION
I ran into an issue when using fakesnow with parameterized SQL queries. I was seeing:

```
    def description(self) -> list[ResultMetadata]:
        # use a cursor to avoid destroying an unfetched result on the main connection
        with self._duck_conn.cursor() as cur:
            assert self._conn.database, "Not implemented when database is None"
            assert self._conn.schema, "Not implemented when database is None"

            # match database and schema used on the main connection
            cur.execute(f"SET SCHEMA = '{self._conn.database}.{self._conn.schema}'")
>           cur.execute(f"DESCRIBE {self._last_sql}")
E           duckdb.InvalidInputException: Invalid Input Error: Prepared statement needs 1 parameters, 0 given
```

The issue was that DESCRIBE was assuming _last_sql parameters were already filled in, but this isn't the case for server-side parameter binding. See:

https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-example#qmark-or-numeric-binding

For some notes on this.

I found that saving the params like the SQL string fixed the issue. I've added a new test that failed before, but passes now.