### PR TITLE
feat: SHOW PRIMARY KEYS + description for CREATE VIEW + fix information_schema.columns to work with sqlalchemy

### DIFF
--- a/fakesnow/__init__.py
+++ b/fakesnow/__init__.py
@@ -85,6 +85,7 @@ def patch(
         p = mock.patch(im, side_effect=fake)
         stack.enter_context(p)
 
-    yield None
-
-    stack.close()
+    try:
+        yield None
+    finally:
+        stack.close()

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -233,10 +233,10 @@ class FakeSnowflakeCursor:
 
         affected_count = None
 
-        maybe_ident = expression.find(exp.Identifier)
-        ident = None
-        if maybe_ident and isinstance(maybe_ident.this, str):
+        if (maybe_ident := expression.find(exp.Identifier, bfs=False)) and isinstance(maybe_ident.this, str):
             ident = maybe_ident.this if maybe_ident.quoted else maybe_ident.this.upper()
+        else:
+            ident = None
 
         if cmd == "USE DATABASE" and ident:
             self._conn.database = ident

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -197,6 +197,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.identifier)
             .transform(lambda e: transforms.show_schemas(e, self._conn.database))
             .transform(lambda e: transforms.show_objects_tables(e, self._conn.database))
+            .transform(lambda e: transforms.show_primary_keys(e, self._conn.database))
             .transform(transforms.show_users)
             .transform(transforms.create_user)
         )

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -37,6 +37,7 @@ SQL_SUCCESS = "SELECT 'Statement executed successfully.' as 'status'"
 SQL_CREATED_DATABASE = Template("SELECT 'Database ${name} successfully created.' as 'status'")
 SQL_CREATED_SCHEMA = Template("SELECT 'Schema ${name} successfully created.' as 'status'")
 SQL_CREATED_TABLE = Template("SELECT 'Table ${name} successfully created.' as 'status'")
+SQL_CREATED_VIEW = Template("SELECT 'View ${name} successfully created.' as 'status'")
 SQL_DROPPED = Template("SELECT '${name} successfully dropped.' as 'status'")
 SQL_INSERTED_ROWS = Template("SELECT ${count} as 'number of rows inserted'")
 SQL_UPDATED_ROWS = Template("SELECT ${count} as 'number of rows updated', 0 as 'number of multi-joined rows updated'")
@@ -230,12 +231,18 @@ class FakeSnowflakeCursor:
             raise snowflake.connector.errors.DatabaseError(msg=e.args[0], errno=250002, sqlstate="08003") from None
 
         affected_count = None
-        if cmd == "USE DATABASE" and (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
-            self._conn.database = ident.this.upper()
+
+        maybe_ident = expression.find(exp.Identifier)
+        ident = None
+        if maybe_ident and isinstance(maybe_ident.this, str):
+            ident = maybe_ident.this if maybe_ident.quoted else maybe_ident.this.upper()
+
+        if cmd == "USE DATABASE" and ident:
+            self._conn.database = ident
             self._conn.database_set = True
 
-        elif cmd == "USE SCHEMA" and (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
-            self._conn.schema = ident.this.upper()
+        elif cmd == "USE SCHEMA" and ident:
+            self._conn.schema = ident
             self._conn.schema_set = True
 
         elif create_db_name := transformed.args.get("create_db_name"):
@@ -243,24 +250,24 @@ class FakeSnowflakeCursor:
             self._duck_conn.execute(info_schema.creation_sql(create_db_name))
             result_sql = SQL_CREATED_DATABASE.substitute(name=create_db_name)
 
-        elif cmd == "CREATE SCHEMA" and (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
-            name = ident.this if ident.quoted else ident.this.upper()
-            result_sql = SQL_CREATED_SCHEMA.substitute(name=name)
+        elif cmd == "CREATE SCHEMA" and ident:
+            result_sql = SQL_CREATED_SCHEMA.substitute(name=ident)
 
-        elif cmd == "CREATE TABLE" and (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
-            name = ident.this if ident.quoted else ident.this.upper()
-            result_sql = SQL_CREATED_TABLE.substitute(name=name)
+        elif cmd == "CREATE TABLE" and ident:
+            result_sql = SQL_CREATED_TABLE.substitute(name=ident)
 
-        elif cmd.startswith("DROP") and (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
-            name = ident.this if ident.quoted else ident.this.upper()
-            result_sql = SQL_DROPPED.substitute(name=name)
+        elif cmd == "CREATE VIEW" and ident:
+            result_sql = SQL_CREATED_VIEW.substitute(name=ident)
+
+        elif cmd.startswith("DROP") and ident:
+            result_sql = SQL_DROPPED.substitute(name=ident)
 
             # if dropping the current database/schema then reset conn metadata
-            if cmd == "DROP DATABASE" and name == self._conn.database:
+            if cmd == "DROP DATABASE" and ident == self._conn.database:
                 self._conn.database = None
                 self._conn.schema = None
 
-            elif cmd == "DROP SCHEMA" and name == self._conn.schema:
+            elif cmd == "DROP SCHEMA" and ident == self._conn.schema:
                 self._conn.schema = None
 
         elif cmd == "INSERT":

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -990,7 +990,7 @@ def create_user(expression: exp.Expression) -> exp.Expression:
 
 
 def show_primary_keys(expression: exp.Expression, current_database: str | None = None) -> exp.Expression:
-    """Transform SHOW PRIMARY KEYS to a query against the information_schema._fs_columns_snowflake table.
+    """Transform SHOW PRIMARY KEYS to a query against the duckdb_constraints table.
 
     https://docs.snowflake.com/en/sql-reference/sql/show-primary-keys
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,10 @@ dev = [
     "pytest~=7.4",
     "ruff~=0.1.6",
     "twine~=4.0",
+    "snowflake-sqlalchemy~=1.5.0",
 ]
 # for debugging, see https://duckdb.org/docs/guides/python/jupyter.html
-notebook = ["duckdb-engine", "ipykernel", "jupysql", "snowflake-sqlalchemy"]
+notebook = ["duckdb-engine", "ipykernel", "jupysql"]
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from typing import cast
 
 import pytest
 import snowflake.connector
+from sqlalchemy.engine import Engine, create_engine
 
 import fakesnow.fixtures
 
@@ -34,3 +35,8 @@ def dcur(conn: snowflake.connector.SnowflakeConnection) -> Iterator[snowflake.co
     """
     with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
         yield cast(snowflake.connector.cursor.DictCursor, cur)
+
+
+@pytest.fixture
+def snowflake_engine(_fakesnow: None) -> Engine:
+    return create_engine("snowflake://user:password@account/db1/schema1")  # type: ignore

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -438,6 +438,15 @@ def test_description_create_drop_table(dcur: snowflake.connector.cursor.DictCurs
     assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
 
 
+def test_description_create_drop_view(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("create view example as select 1")
+    assert dcur.fetchall() == [{"status": "View EXAMPLE successfully created."}]
+    assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
+    dcur.execute("drop view example")
+    assert dcur.fetchall() == [{"status": "EXAMPLE successfully dropped."}]
+    assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
+
+
 def test_description_insert(dcur: snowflake.connector.cursor.DictCursor):
     dcur.execute("create table example (x int)")
     dcur.execute("insert into example values (1), (2)")

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -439,7 +439,7 @@ def test_description_create_drop_table(dcur: snowflake.connector.cursor.DictCurs
 
 
 def test_description_create_drop_view(dcur: snowflake.connector.cursor.DictCursor):
-    dcur.execute("create view example as select 1")
+    dcur.execute("create view example(id) as select 1")
     assert dcur.fetchall() == [{"status": "View EXAMPLE successfully created."}]
     assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
     dcur.execute("drop view example")

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -941,6 +941,47 @@ def test_show_tables(dcur: snowflake.connector.cursor.SnowflakeCursor):
     assert [r.name for r in dcur.description] == ["created_on", "name", "kind", "database_name", "schema_name"]
 
 
+def test_show_primary_keys(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE TABLE example (id int, name varchar, PRIMARY KEY (id, name))")
+
+    dcur.execute("show primary keys")
+    result = dcur.fetchall()
+
+    assert result == [
+        {
+            "created_on": datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc),
+            "database_name": "DB1",
+            "schema_name": "SCHEMA1",
+            "table_name": "EXAMPLE",
+            "column_name": "ID",
+            "key_sequence": 1,
+            "constraint_name": "db1_schema1_example_pkey",
+            "rely": "false",
+            "comment": None,
+        },
+        {
+            "created_on": datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc),
+            "database_name": "DB1",
+            "schema_name": "SCHEMA1",
+            "table_name": "EXAMPLE",
+            "column_name": "NAME",
+            "key_sequence": 1,
+            "constraint_name": "db1_schema1_example_pkey",
+            "rely": "false",
+            "comment": None,
+        },
+    ]
+
+    dcur.execute("show primary keys in schema db1.schema1")
+    result2 = dcur.fetchall()
+    assert result == result2
+
+    # Assertion to sanity check that the above "in schema" filter isnt wrong, and in fact filters
+    dcur.execute("show primary keys in schema db1.information_schema")
+    result3 = dcur.fetchall()
+    assert result3 == []
+
+
 def test_sqlstate(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("select 'hello world'")
     # sqlstate is None on success

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -1,3 +1,6 @@
+import duckdb
+import pytest
+from sqlalchemy import Column, MetaData, Table, types
 from sqlalchemy.engine import Engine
 from sqlalchemy.sql.expression import TextClause
 
@@ -10,3 +13,27 @@ def test_create_view(snowflake_engine: Engine):
         result = conn.execute("SELECT database_name FROM foo")
         assert result
         assert result.fetchall() == [("DB1",)]
+
+
+def test_metadata_createall(snowflake_engine: Engine):
+    metadata = MetaData()
+
+    table = Table("foo", metadata, Column(types.Integer, name="id"), Column(types.String, name="name"))
+    metadata.create_all(bind=snowflake_engine)
+
+    with snowflake_engine.connect() as conn:
+        result = conn.execute(table.select())
+        assert result
+        assert result.fetchall() == []
+
+
+@pytest.mark.xfail(
+    reason="sqlglot currently has unsupported SHOW variants",
+    strict=True,
+    raises=duckdb.ParserException,
+)
+def test_reflect(snowflake_engine: Engine):
+    snowflake_engine.execute(TextClause("CREATE TABLE foo (id INTEGER, name VARCHAR)"))
+
+    metadata = MetaData()
+    metadata.reflect(bind=snowflake_engine, only=["foo"])

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -1,0 +1,12 @@
+from sqlalchemy.engine import Engine
+from sqlalchemy.sql.expression import TextClause
+
+
+def test_create_view(snowflake_engine: Engine):
+    """SQLalchemy internally calls `cursor.description`, which will fail if `CREATE VIEW` isn't handled."""
+    with snowflake_engine.connect() as conn:
+        conn.execute(TextClause("CREATE VIEW foo AS SELECT * FROM information_schema.databases"))
+
+        result = conn.execute("SELECT database_name FROM foo")
+        assert result
+        assert result.fetchall() == [("DB1",)]

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -5,8 +5,8 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.sql.expression import TextClause
 
 
-def test_create_view(snowflake_engine: Engine):
-    """SQLalchemy internally calls `cursor.description`, which will fail if `CREATE VIEW` isn't handled."""
+def test_engine(snowflake_engine: Engine):
+    # verifies cursor.description, commit, and rollback issued by SQLAlchemy
     with snowflake_engine.connect() as conn:
         conn.execute(TextClause("CREATE VIEW foo AS SELECT * FROM information_schema.databases"))
 
@@ -15,7 +15,7 @@ def test_create_view(snowflake_engine: Engine):
         assert result.fetchall() == [("DB1",)]
 
 
-def test_metadata_createall(snowflake_engine: Engine):
+def test_metadata_create_all(snowflake_engine: Engine):
     metadata = MetaData()
 
     table = Table("foo", metadata, Column(types.Integer, name="id"), Column(types.String, name="name"))


### PR DESCRIPTION
As I mentioned before, thus far I've just been trying to get increasing numbers of existing features working with fakesnow.

The e2e feature attempting to be fixed here is `CREATE VIEW`, but there's more going on than just support for the statement. As such, I've tried to implement tests that address each added bit of functionality directly.

* Adjust the output of `CREATE VIEW` akin to what you're already doing for `CREATE TABLE`
* Begin support of table reflection
  * Support `SHOW PRIMARY KEYS` (called internally to sqlalchemy), at least to a minimal extent. It now syntatically works and does what would seem to be correct (except that I dont see an equivalent to "constraint_name" in duckdb). Seems to work, but without it working e2e it's hard to be sure
  * Added an `xfail` test for table reflection generally.

Right now the xfail test is failing because `information_schema.columns` doesn't have a `comment` column. But that appears to be a native duckdb column, so I'm not entirely sure what to do. It seems like perhaps the `sqlalchemy-snowflake` dialect itself needs to be mutated to look at a fakesnow view instead, or something...

Thoughts?