### PR TITLE
refactor: remove parse_json as handled by sqlglot

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -173,7 +173,6 @@ class FakeSnowflakeCursor:
             .transform(transforms.drop_schema_cascade)
             .transform(transforms.tag)
             .transform(transforms.semi_structured_types)
-            .transform(transforms.parse_json)
             # indices_to_json_extract must be before regex_substr
             .transform(transforms.indices_to_json_extract)
             .transform(transforms.json_extract_cast_as_varchar)

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -518,32 +518,6 @@ def object_construct(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
-def parse_json(expression: exp.Expression) -> exp.Expression:
-    """Convert parse_json() to json().
-
-    Example:
-        >>> import sqlglot
-        >>> sqlglot.parse_one("insert into table1 (name) select parse_json('{}')").transform(parse_json).sql()
-        "CREATE TABLE table1 (name JSON)"
-    Args:
-        expression (exp.Expression): the expression that will be transformed.
-
-    Returns:
-        exp.Expression: The transformed expression.
-    """
-
-    if (
-        isinstance(expression, exp.Anonymous)
-        and isinstance(expression.this, str)
-        and expression.this.upper() == "PARSE_JSON"
-    ):
-        new = expression.copy()
-        new.args["this"] = "JSON"
-        return new
-
-    return expression
-
-
 def regex_replace(expression: exp.Expression) -> exp.Expression:
     """Transform regex_replace expressions from snowflake to duckdb."""
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -23,7 +23,6 @@ from fakesnow.transforms import (
     json_extract_cast_as_varchar,
     json_extract_precedence,
     object_construct,
-    parse_json,
     random,
     regex_replace,
     regex_substr,
@@ -264,9 +263,10 @@ def test_object_construct() -> None:
 
 def test_parse_json() -> None:
     assert (
-        sqlglot.parse_one("""insert into table1 (name) select parse_json('{"first":"foo", "last":"bar"}')""")
-        .transform(parse_json)
-        .sql(dialect="duckdb")
+        sqlglot.parse_one(
+            """insert into table1 (name) select parse_json('{"first":"foo", "last":"bar"}')""",
+            read="snowflake",
+        ).sql(dialect="duckdb")
         == """INSERT INTO table1 (name) SELECT JSON('{"first":"foo", "last":"bar"}')"""
     )
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -261,16 +261,6 @@ def test_object_construct() -> None:
     )
 
 
-def test_parse_json() -> None:
-    assert (
-        sqlglot.parse_one(
-            """insert into table1 (name) select parse_json('{"first":"foo", "last":"bar"}')""",
-            read="snowflake",
-        ).sql(dialect="duckdb")
-        == """INSERT INTO table1 (name) SELECT JSON('{"first":"foo", "last":"bar"}')"""
-    )
-
-
 def test_random() -> None:
     e = sqlglot.parse_one("select random(420)").transform(random)
 


### PR DESCRIPTION
Seems like already handled by `sqlglot`, removing transformation won't break any tests;
```python
q1 = """SELECT PARSE_JSON('{"k1": "v1"}')"""
parse_one(q1, dialect="snowflake").sql(dialect="duckdb")

q2 = """SELECT PARSE_JSON(col)"""
parse_one(q2, dialect="snowflake").sql(dialect="duckdb")
```

```python
Select(
  expressions=[
    ParseJSON(
      this=Literal(this={"k1": "v1"}, is_string=True))])
# SELECT JSON('{"k1": "v1"}')

Select(
  expressions=[
    ParseJSON(
      this=Column(
        this=Identifier(this=col, quoted=False)))])
# SELECT JSON(col)
```

----

Left `test_parse_json` as is without any transformation in case of any `sqlglot` changes. There're other tests those cover it in fakes tests though deleting kinda makes sense.


------------------

* Python: 3.9.18
* sqlglot: 21.2.1
