### PR TITLE
feat: support sha2 and sha2_hex with digest size of 256

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -206,6 +206,7 @@ class FakeSnowflakeCursor:
             .transform(lambda e: transforms.show_keys(e, self._conn.database, kind="FOREIGN"))
             .transform(transforms.show_users)
             .transform(transforms.create_user)
+            .transform(transforms.sha256)
         )
         sql = transformed.sql(dialect="duckdb")
         result_sql = None

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -1190,6 +1190,8 @@ class SHA256(exp.Func):
 def sha256(expression: exp.Expression) -> exp.Expression:
     """Convert sha2() or sha2_hex() to sha256().
 
+    Convert sha2_binary() to unhex(sha256()).
+
     Example:
         >>> import sqlglot
         >>> sqlglot.parse_one("insert into table1 (name) select sha2('foo')").transform(sha256).sql()
@@ -1212,5 +1214,14 @@ def sha256(expression: exp.Expression) -> exp.Expression:
         )
     ):
         return SHA256(this=expression.expressions[0])
+    elif (
+        isinstance(expression, exp.Anonymous)
+        and expression.this.upper() == "SHA2_BINARY"
+        and (
+            len(expression.expressions) == 1
+            or (len(expression.expressions) == 2 and expression.expressions[1].this == "256")
+        )
+    ):
+        return exp.Unhex(this=SHA256(this=expression.expressions[0]))
 
     return expression

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1207,6 +1207,17 @@ def test_to_decimal(cur: snowflake.connector.cursor.SnowflakeCursor):
     ]
 
 
+def test_sha2(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # see https://docs.snowflake.com/en/sql-reference/functions/sha2#examples
+    cur.execute(
+        "select sha2('Snowflake') as a, sha2_hex('Snowflake') as b, sha2('Snowflake', 256) as c, sha2_hex('Snowflake', 256) as d;"
+    )
+
+    assert cur.fetchall() == [
+        ("1dbd59f661d68b90724f21084396b865497173e4d2714f4d91cf05fa5fc5e18d",) * 4,
+    ]
+
+
 def test_try_parse_json(dcur: snowflake.connector.cursor.DictCursor):
     dcur.execute("""SELECT TRY_PARSE_JSON('{"first":"foo", "last":"bar"}') AS j""")
     assert dindent(dcur.fetchall()) == [{"J": '{\n  "first": "foo",\n  "last": "bar"\n}'}]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -634,3 +634,34 @@ def test_sha256() -> None:
         sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 256, 'wtf')").transform(sha256).sql()
         == "INSERT INTO table1 (name) SELECT SHA2_HEX('foo', 256, 'wtf')"
     )
+
+
+def test_sha256_binary() -> None:
+    # snowflake default sha2 length is 256
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_binary('foo')").transform(sha256).sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT UNHEX(SHA256('foo'))"
+    )
+
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_binary('foo', 256)")
+        .transform(sha256)
+        .sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT UNHEX(SHA256('foo'))"
+    )
+
+    # values with hash length other than 256 are not transformed
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_binary('foo', 224)").transform(sha256).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_BINARY('foo', 224)"
+    )
+
+    # values with unrecognised args signature are not transformed
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_binary()").transform(sha256).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_BINARY()"
+    )
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_binary('foo', 256, 'wtf')").transform(sha256).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_BINARY('foo', 256, 'wtf')"
+    )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -32,6 +32,7 @@ from fakesnow.transforms import (
     sample,
     semi_structured_types,
     set_schema,
+    sha256,
     show_objects_tables,
     show_schemas,
     tag,
@@ -589,4 +590,49 @@ def test_values_columns() -> None:
     assert (
         sqlglot.parse_one("INSERT INTO cities VALUES ('Amsterdam', 1)").transform(values_columns).sql()
         == "INSERT INTO cities VALUES ('Amsterdam', 1)"
+    )
+
+
+def test_sha256() -> None:
+    # snowflake default sha2 length is 256
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2('foo')").transform(sha256).sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT SHA256('foo')"
+    )
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo')").transform(sha256).sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT SHA256('foo')"
+    )
+
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2('foo', 256)").transform(sha256).sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT SHA256('foo')"
+    )
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 256)")
+        .transform(sha256)
+        .sql(dialect="duckdb")
+        == "INSERT INTO table1 (name) SELECT SHA256('foo')"
+    )
+
+    # values with hash length other than 256 are not transformed
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2('foo', 224)").transform(values_columns).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2('foo', 224)"
+    )
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 224)").transform(values_columns).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_HEX('foo', 224)"
+    )
+
+    # values with unrecognised args signature are not transformed
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex()").transform(values_columns).sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_HEX()"
+    )
+    assert (
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 256, 'wtf')")
+        .transform(values_columns)
+        .sql()
+        == "INSERT INTO table1 (name) SELECT SHA2_HEX('foo', 256, 'wtf')"
     )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -617,22 +617,20 @@ def test_sha256() -> None:
 
     # values with hash length other than 256 are not transformed
     assert (
-        sqlglot.parse_one("insert into table1 (name) select sha2('foo', 224)").transform(values_columns).sql()
+        sqlglot.parse_one("insert into table1 (name) select sha2('foo', 224)").transform(sha256).sql()
         == "INSERT INTO table1 (name) SELECT SHA2('foo', 224)"
     )
     assert (
-        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 224)").transform(values_columns).sql()
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 224)").transform(sha256).sql()
         == "INSERT INTO table1 (name) SELECT SHA2_HEX('foo', 224)"
     )
 
     # values with unrecognised args signature are not transformed
     assert (
-        sqlglot.parse_one("insert into table1 (name) select sha2_hex()").transform(values_columns).sql()
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex()").transform(sha256).sql()
         == "INSERT INTO table1 (name) SELECT SHA2_HEX()"
     )
     assert (
-        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 256, 'wtf')")
-        .transform(values_columns)
-        .sql()
+        sqlglot.parse_one("insert into table1 (name) select sha2_hex('foo', 256, 'wtf')").transform(sha256).sql()
         == "INSERT INTO table1 (name) SELECT SHA2_HEX('foo', 256, 'wtf')"
     )


### PR DESCRIPTION
We're using Snowflake `sha2` function in our project that uses `fakesnow` for testing (it's great, thank you!)

But duckdb does not have `sha2` function, instead it has a `sha256` function

`sha256(foo)` is the same as Snowflake `sha2('foo', 256)` (or you can omit the length arg and it defaults to 256) https://docs.snowflake.com/en/sql-reference/functions/sha2#arguments

So this PR adds a transform for these function calls