### PR TITLE
fix: write_pandas quotes columns when inserting dataframe

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -617,7 +617,9 @@ class FakeSnowflakeConnection:
             # don't jsonify string
             df[col] = df[col].apply(lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x)
 
-        self._duck_conn.execute(f"INSERT INTO {table_name}({','.join(df.columns.to_list())}) SELECT * FROM df")
+        escaped_cols = ",".join(f'"{col}"' for col in df.columns.to_list())
+
+        self._duck_conn.execute(f"INSERT INTO {table_name}({escaped_cols}) SELECT * FROM df")
         return self._duck_conn.fetchall()[0][0]
 
 

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -618,8 +618,8 @@ class FakeSnowflakeConnection:
             df[col] = df[col].apply(lambda x: json.dumps(x) if isinstance(x, (dict, list)) else x)
 
         escaped_cols = ",".join(f'"{col}"' for col in df.columns.to_list())
-
         self._duck_conn.execute(f"INSERT INTO {table_name}({escaped_cols}) SELECT * FROM df")
+
         return self._duck_conn.fetchall()[0][0]
 
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1264,8 +1264,9 @@ def test_values(conn: snowflake.connector.SnowflakeConnection):
 
 
 def test_write_pandas_quoted_column_names(conn: snowflake.connector.SnowflakeConnection):
-    with conn.cursor() as cur:
-        cur.execute('create table customers (id int, "first name" varchar)')
+    with conn.cursor(snowflake.connector.cursor.DictCursor) as dcur:
+        # colunmn names with spaces
+        dcur.execute('create table customers (id int, "first name" varchar)')
         df = pd.DataFrame.from_records(
             [
                 {"ID": 1, "first name": "Jenny"},
@@ -1274,11 +1275,11 @@ def test_write_pandas_quoted_column_names(conn: snowflake.connector.SnowflakeCon
         )
         snowflake.connector.pandas_tools.write_pandas(conn, df, "CUSTOMERS")
 
-        cur.execute("select * from customers")
+        dcur.execute("select * from customers")
 
-        assert indent(cur.fetchall()) == [
-            (1, "Jenny"),
-            (2, "Jasper"),
+        assert dcur.fetchall() == [
+            {"ID": 1, "first name": "Jenny"},
+            {"ID": 2, "first name": "Jasper"},
         ]
 
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1263,6 +1263,25 @@ def test_values(conn: snowflake.connector.SnowflakeConnection):
         ]
 
 
+def test_write_pandas_quoted_column_names(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        cur.execute('create table customers (id int, "first name" varchar)')
+        df = pd.DataFrame.from_records(
+            [
+                {"ID": 1, "first name": "Jenny"},
+                {"ID": 2, "first name": "Jasper"},
+            ]
+        )
+        snowflake.connector.pandas_tools.write_pandas(conn, df, "CUSTOMERS")
+
+        cur.execute("select * from customers")
+
+        assert indent(cur.fetchall()) == [
+            (1, "Jenny"),
+            (2, "Jasper"),
+        ]
+
+
 def test_write_pandas_array(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor() as cur:
         cur.execute("create table customers (ID int, FIRST_NAME varchar, LAST_NAME varchar, ORDERS array)")


### PR DESCRIPTION
`_insert_df` needs to quote the column names when inserting, otherwise fails for table where column names need quoting