### PR TITLE
feat: add TRY_TO_{DECIMAL,...}

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -185,6 +185,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.values_columns)
             .transform(transforms.to_date)
             .transform(transforms.to_decimal)
+            .transform(transforms.try_to_decimal)
             .transform(transforms.to_timestamp_ntz)
             .transform(transforms.to_timestamp)
             .transform(transforms.object_construct)

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -878,6 +878,21 @@ def _get_to_number_args(e: exp.ToNumber) -> tuple[exp.Expression | None, exp.Exp
 
     return _format, _precision, _scale
 
+def _to_decimal(expression: exp.Expression, cast_node: type[exp.Cast]) -> exp.Expression:
+    expressions: list[exp.Expression] = expression.expressions
+
+    if len(expressions) > 1 and expressions[1].is_string:
+        # see https://docs.snowflake.com/en/sql-reference/functions/to_decimal#arguments
+        raise NotImplementedError(f"{expression.this} with format argument")
+
+    precision = expressions[1] if len(expressions) > 1 else exp.Literal(this="38", is_string=False)
+    scale = expressions[2] if len(expressions) > 2 else exp.Literal(this="0", is_string=False)
+
+    return cast_node(
+        this=expressions[0],
+        to=exp.DataType(this=exp.DataType.Type.DECIMAL, expressions=[precision, scale], nested=False, prefix=False),
+    )
+
 
 def to_decimal(expression: exp.Expression) -> exp.Expression:
     """Transform to_decimal, to_number, to_numeric expressions from snowflake to duckdb.
@@ -905,19 +920,22 @@ def to_decimal(expression: exp.Expression) -> exp.Expression:
         and isinstance(expression.this, str)
         and expression.this.upper() in ["TO_DECIMAL", "TO_NUMERIC"]
     ):
-        expressions: list[exp.Expression] = expression.expressions
+        return _to_decimal(expression, exp.Cast)
 
-        if len(expressions) > 1 and expressions[1].is_string:
-            # see https://docs.snowflake.com/en/sql-reference/functions/to_decimal#arguments
-            raise NotImplementedError(f"{expression.this} with format argument")
+    return expression
 
-        precision = expressions[1] if len(expressions) > 1 else exp.Literal(this="38", is_string=False)
-        scale = expressions[2] if len(expressions) > 2 else exp.Literal(this="0", is_string=False)
 
-        return exp.Cast(
-            this=expressions[0],
-            to=exp.DataType(this=exp.DataType.Type.DECIMAL, expressions=[precision, scale], nested=False, prefix=False),
-        )
+def try_to_decimal(expression: exp.Expression) -> exp.Expression:
+    """Transform try_to_decimal, try_to_number, try_to_numeric expressions from snowflake to duckdb.
+    See https://docs.snowflake.com/en/sql-reference/functions/try_to_decimal
+    """
+
+    if (
+        isinstance(expression, exp.Anonymous)
+        and isinstance(expression.this, str)
+        and expression.this.upper() in ["TRY_TO_DECIMAL", "TRY_TO_NUMBER", "TRY_TO_NUMERIC"]
+    ):
+        return _to_decimal(expression, exp.TryCast)
 
     return expression
 

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -878,6 +878,7 @@ def _get_to_number_args(e: exp.ToNumber) -> tuple[exp.Expression | None, exp.Exp
 
     return _format, _precision, _scale
 
+
 def _to_decimal(expression: exp.Expression, cast_node: type[exp.Cast]) -> exp.Expression:
     expressions: list[exp.Expression] = expression.expressions
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1215,6 +1215,20 @@ def test_try_parse_json(dcur: snowflake.connector.cursor.DictCursor):
     assert dcur.fetchall() == [{"J": None}]
 
 
+def test_try_to_decimal(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute(
+        "SELECT column1 AS orig_string, TRY_TO_DECIMAL(column1) AS dec, TRY_TO_DECIMAL(column1, 10, 2) AS dec_with_scale, TRY_TO_DECIMAL(column1, 4, 2) AS dec_with_range_err FROM VALUES ('345.123');"
+    )
+    assert cur.fetchall() == [
+        (
+            "345.123",
+            Decimal("345"),
+            Decimal("345.12"),
+            None,
+        ),
+    ]
+
+
 def test_transactions(conn: snowflake.connector.SnowflakeConnection):
     # test behaviours required for sqlalchemy
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -41,6 +41,7 @@ from fakesnow.transforms import (
     to_timestamp,
     to_timestamp_ntz,
     try_parse_json,
+    try_to_decimal,
     upper_case_unquoted_identifiers,
     values_columns,
 )
@@ -385,8 +386,15 @@ def test_to_date() -> None:
 
 def test_to_decimal() -> None:
     assert (
-        sqlglot.parse_one("SELECT to_decimal('1.245',10,2)").transform(to_decimal).sql()
+        sqlglot.parse_one("SELECT to_decimal('1.245',10,2)", read="snowflake").transform(to_decimal).sql()
         == "SELECT CAST('1.245' AS DECIMAL(10, 2))"
+    )
+
+
+def test_try_to_decimal() -> None:
+    assert (
+        sqlglot.parse_one("SELECT try_to_decimal('1.245',10,2)", read="snowflake").transform(try_to_decimal).sql()
+        == "SELECT TRY_CAST('1.245' AS DECIMAL(10, 2))"
     )
 
 


### PR DESCRIPTION
Adds transformation for `TRY_TO_DECIMAL` and friends, basically the same as `to_decimal` except returned node is `TryCast` instead of `Cast`.

Moved the actual node creation to another function to reuse it in both `*to_decimal` transformation, but not 100% sure with what I end up with. 

Keeping the same logic in both functions makes it more explicit and more isolated but prone to failures in a case that is not covered by tests, would like to hear what you think about it.


----------------
> [!NOTE]  
> I'm working on a wrapper dbt adapter so users can write unit tests and run locally. Thank you for this awesome project as it really sped things up and kept my focus solely on query transformations.
>
> I have a couple more transformation but not sure if all fits in the scope of the project as some are quite opinionated.  I wanted to open a separate PR for each transformation to keep it reviewable but it might get annoying for a maintainer. Please let me know your thoughts, like if you prefer them to be in a single PR.
