### PR TITLE
feat: support trim with numeric and variant types

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -174,6 +174,8 @@ class FakeSnowflakeCursor:
             .transform(transforms.tag)
             .transform(transforms.semi_structured_types)
             .transform(transforms.try_parse_json)
+            # NOTE: trim_cast_varchar must be before json_extract_cast_as_varchar
+            .transform(transforms.trim_cast_varchar)
             # indices_to_json_extract must be before regex_substr
             .transform(transforms.indices_to_json_extract)
             .transform(transforms.json_extract_cast_as_varchar)

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -1095,6 +1095,21 @@ def timestamp_ntz_ns(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
+def trim_cast_varchar(expression: exp.Expression) -> exp.Expression:
+    """Snowflake's TRIM casts input to VARCHAR implicitly."""
+
+    if not (isinstance(expression, exp.Trim)):
+        return expression
+
+    operand = expression.this
+    if isinstance(operand, exp.Cast) and operand.to.this in [exp.DataType.Type.VARCHAR, exp.DataType.Type.TEXT]:
+        return expression
+
+    return exp.Trim(
+        this=exp.Cast(this=operand, to=exp.DataType(this=exp.DataType.Type.VARCHAR, nested=False, prefix=False))
+    )
+
+
 def try_parse_json(expression: exp.Expression) -> exp.Expression:
     """Convert TRY_PARSE_JSON() to TRY_CAST(... as JSON).
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1393,22 +1393,12 @@ def test_transactions(conn: snowflake.connector.SnowflakeConnection):
         assert cur.fetchall() == [("Statement executed successfully.",)]
 
 
-def test_trim_cast_varchar(conn: snowflake.connector.SnowflakeConnection):
-    with conn.cursor() as cur:
-        cur.execute("create or replace table trim_cast_varchar(id number, name varchar);")
-        cur.execute("insert into trim_cast_varchar(id, name) values (1, '  name 1  '), (2, 'name2   ');")
-        cur.execute("select trim(id), trim(name) from trim_cast_varchar;")
+def test_trim_cast_varchar(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("select trim(1), trim('  name 1  ')")
+    assert cur.fetchall() == [("1", "name 1")]
 
-        assert cur.fetchall() == [("1", "name 1"), ("2", "name2")]
-
-    with conn.cursor() as cur:
-        cur.execute("create or replace table trim_cast_varchar_variant_field(data variant);")
-        cur.execute(
-            """insert into trim_cast_varchar_variant_field(data) select parse_json(column1) from values ('{"k1": "   v11  "}'),('{"k1": 21}');"""
-        )
-        cur.execute("select trim(data:k1) from trim_cast_varchar_variant_field;")
-
-        assert cur.fetchall() == [("v11",), ("21",)]
+    cur.execute("""select trim(parse_json('{"k1": "   v11  "}'):k1), trim(parse_json('{"k1": 21}'):k1)""")
+    assert cur.fetchall() == [("v11", "21")]
 
 
 def test_unquoted_identifiers_are_upper_cased(dcur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1404,7 +1404,7 @@ def test_trim_cast_varchar(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor() as cur:
         cur.execute("create or replace table trim_cast_varchar_variant_field(data variant);")
         cur.execute(
-            """insert into trim_cast_varchar_variant_field(data) values ('{"k1": "   v11  "}'),('{"k1": 21}');"""
+            """insert into trim_cast_varchar_variant_field(data) select parse_json(column1) from values ('{"k1": "   v11  "}'),('{"k1": 21}');"""
         )
         cur.execute("select trim(data:k1) from trim_cast_varchar_variant_field;")
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -44,6 +44,7 @@ from fakesnow.transforms import (
     to_decimal,
     to_timestamp,
     to_timestamp_ntz,
+    trim_cast_varchar,
     try_parse_json,
     try_to_decimal,
     upper_case_unquoted_identifiers,
@@ -767,6 +768,23 @@ def test_try_parse_json() -> None:
         .transform(try_parse_json)
         .sql(dialect="duckdb")
         == """INSERT INTO table1 (name) SELECT TRY_CAST('{"first":"foo", "last":"bar"}' AS JSON)"""
+    )
+
+
+def test_trim_cast_varchar() -> None:
+    assert (
+        sqlglot.parse_one("SELECT TRIM(col) FROM table1").transform(trim_cast_varchar).sql(dialect="duckdb")
+        == "SELECT TRIM(CAST(col AS TEXT)) FROM table1"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT TRIM(col::varchar) FROM table1").transform(trim_cast_varchar).sql(dialect="duckdb")
+        == "SELECT TRIM(CAST(col AS TEXT)) FROM table1"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT TRIM(col::TEXT) FROM table1").transform(trim_cast_varchar).sql(dialect="duckdb")
+        == "SELECT TRIM(CAST(col AS TEXT)) FROM table1"
     )
 
 


### PR DESCRIPTION
Snowflake's [`TRIM`](https://docs.snowflake.com/en/sql-reference/functions/trim) accepts any type and returns VARCHAR, docs does not mentioned it but it seems to only works on VARCHAR/TEXT typed inputs and acts as a cast to VARCHAR for others.  DuckDB's `TRIM` only accepts VARCHAR. It seemed safe to me to cast input to VARCHAR to mimic similar behaviour.
```sql
select 
    trim(5) as c_number, SYSTEM$TYPEOF(c_number),
    trim(' str ') as c_varchar, SYSTEM$TYPEOF(c_varchar),
    trim(to_variant({'k': 'v'})) as c_variant, SYSTEM$TYPEOF(c_variant)
;
```

| C_NUMBER | SYSTEM$TYPEOF(C_NUMBER) | C_VARCHAR | SYSTEM$TYPEOF(C_VARCHAR) | C_VARIANT | SYSTEM$TYPEOF(C_VARIANT) |
|----------|-------------------------|-----------|--------------------------|-----------|--------------------------|
|        5 | VARCHAR(16777216)[LOB]  | str       | VARCHAR(5)[LOB]          | {"k":"v"} | VARCHAR(16777216)[LOB]   |
