### PR TITLE
feat: mimic dateadd with date + day/week/month/year

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -198,6 +198,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.identifier)
             .transform(transforms.array_agg_within_group)
             .transform(transforms.array_agg_to_json)
+            .transform(transforms.dateadd_date_cast)
             .transform(lambda e: transforms.show_schemas(e, self._conn.database))
             .transform(lambda e: transforms.show_objects_tables(e, self._conn.database))
             # TODO collapse into a single show_keys function

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -169,6 +169,47 @@ def drop_schema_cascade(expression: exp.Expression) -> exp.Expression:
     return new
 
 
+def dateadd_date_cast(expression: exp.Expression) -> exp.Expression:
+    """Cast result of DATEADD to DATE if the given expression is a cast to DATE
+       and unit is either DAY, WEEK, MONTH or YEAR to mimic Snowflake's DATEADD
+       behaviour.
+
+    Snowflake;
+        SELECT DATEADD(DAY, 3, '2023-03-03'::DATE) as D;
+            D: 2023-03-06 (DATE)
+    DuckDB;
+        SELECT CAST('2023-03-03' AS DATE) + INTERVAL 3 DAY AS D
+            D: 2023-03-06 00:00:00 (TIMESTAMP)
+    """
+
+    if not isinstance(expression, exp.DateAdd):
+        return expression
+
+    dateadd = expression
+
+    if dateadd.unit is None:
+        return expression
+
+    if not isinstance(dateadd.unit.this, str):
+        return expression
+
+    if (unit := dateadd.unit.this.upper()) and unit.upper() not in {"DAY", "WEEK", "MONTH", "YEAR"}:
+        return expression
+
+    if not isinstance(dateadd.this, exp.Cast):
+        return expression
+
+    cast = dateadd.this
+
+    if cast.to.this != exp.DataType.Type.DATE:
+        return expression
+
+    return exp.Cast(
+        this=expression,
+        to=exp.DataType(this=exp.DataType.Type.DATE, nested=False, prefix=False),
+    )
+
+
 def extract_comment_on_columns(expression: exp.Expression) -> exp.Expression:
     """Extract column comments, removing it from the Expression.
 

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -185,23 +185,19 @@ def dateadd_date_cast(expression: exp.Expression) -> exp.Expression:
     if not isinstance(expression, exp.DateAdd):
         return expression
 
-    dateadd = expression
-
-    if dateadd.unit is None:
+    if expression.unit is None:
         return expression
 
-    if not isinstance(dateadd.unit.this, str):
+    if not isinstance(expression.unit.this, str):
         return expression
 
-    if (unit := dateadd.unit.this.upper()) and unit.upper() not in {"DAY", "WEEK", "MONTH", "YEAR"}:
+    if (unit := expression.unit.this.upper()) and unit.upper() not in {"DAY", "WEEK", "MONTH", "YEAR"}:
         return expression
 
-    if not isinstance(dateadd.this, exp.Cast):
+    if not isinstance(expression.this, exp.Cast):
         return expression
 
-    cast = dateadd.this
-
-    if cast.to.this != exp.DataType.Type.DATE:
+    if expression.this.to.this != exp.DataType.Type.DATE:
         return expression
 
     return exp.Cast(

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -290,53 +290,27 @@ def test_connect_with_non_existent_db_or_schema(_fakesnow_no_auto_create: None):
         assert conn.schema == "JAFFLES"
 
 
-def test_dateadd_date_cast(conn: snowflake.connector.SnowflakeConnection):
-    with conn.cursor(snowflake.connector.DictCursor) as cur:
-        cur.execute("create table example (d varchar)")
-        cur.execute("insert into example values ('2023-04-02')")
+def test_dateadd_date_cast(dcur: snowflake.connector.DictCursor):
+    q = """
+    SELECT
+        dateadd(hour, 1, '2023-04-02'::date) as d_noop,
+        dateadd(day, 1, '2023-04-02'::date) as d_day,
+        dateadd(week, 1, '2023-04-02'::date) as d_week,
+        dateadd(month, 1, '2023-04-02'::date) as d_month,
+        dateadd(year, 1, '2023-04-02'::date) as d_year
+    FROM example
+    """
 
-        q = """
-        SELECT
-            dateadd(hour, 1, d::date) as d_noop,
-            dateadd(day, 1, d::date) as d_day,
-            dateadd(week, 1, d::date) as d_week,
-            dateadd(month, 1, d::date) as d_month,
-            dateadd(year, 1, d::date) as d_year
-        FROM example
-        """
-
-        cur.execute(q)
-        assert cur.fetchall() == [
-            {
-                "D_NOOP": datetime.datetime(2023, 4, 2, 1, 0),
-                "D_DAY": datetime.date(2023, 4, 3),
-                "D_WEEK": datetime.date(2023, 4, 9),
-                "D_MONTH": datetime.date(2023, 5, 2),
-                "D_YEAR": datetime.date(2024, 4, 2),
-            }
-        ]
-
-    with conn.cursor(snowflake.connector.DictCursor) as cur:
-        q = """
-        SELECT
-            dateadd(hour, 1, '2023-04-02'::date) as d_noop,
-            dateadd(day, 1, '2023-04-02'::date) as d_day,
-            dateadd(week, 1, '2023-04-02'::date) as d_week,
-            dateadd(month, 1, '2023-04-02'::date) as d_month,
-            dateadd(year, 1, '2023-04-02'::date) as d_year
-        FROM example
-        """
-
-        cur.execute(q)
-        assert cur.fetchall() == [
-            {
-                "D_NOOP": datetime.datetime(2023, 4, 2, 1, 0),
-                "D_DAY": datetime.date(2023, 4, 3),
-                "D_WEEK": datetime.date(2023, 4, 9),
-                "D_MONTH": datetime.date(2023, 5, 2),
-                "D_YEAR": datetime.date(2024, 4, 2),
-            }
-        ]
+    dcur.execute(q)
+    assert dcur.fetchall() == [
+        {
+            "D_NOOP": datetime.datetime(2023, 4, 2, 1, 0),
+            "D_DAY": datetime.date(2023, 4, 3),
+            "D_WEEK": datetime.date(2023, 4, 9),
+            "D_MONTH": datetime.date(2023, 5, 2),
+            "D_YEAR": datetime.date(2024, 4, 2),
+        }
+    ]
 
 
 def test_dateadd_string_literal_timestamp_cast(dcur: snowflake.connector.cursor.DictCursor):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -299,7 +299,7 @@ def test_dateadd_date_cast(conn: snowflake.connector.SnowflakeConnection):
         SELECT
             dateadd(hour, 1, d::date) as d_noop,
             dateadd(day, 1, d::date) as d_day,
-            dateadd(wk, 1, d::date) as d_week,
+            dateadd(week, 1, d::date) as d_week,
             dateadd(month, 1, d::date) as d_month,
             dateadd(year, 1, d::date) as d_year
         FROM example
@@ -321,7 +321,7 @@ def test_dateadd_date_cast(conn: snowflake.connector.SnowflakeConnection):
         SELECT
             dateadd(hour, 1, '2023-04-02'::date) as d_noop,
             dateadd(day, 1, '2023-04-02'::date) as d_day,
-            dateadd(wk, 1, '2023-04-02'::date) as d_week,
+            dateadd(week, 1, '2023-04-02'::date) as d_week,
             dateadd(month, 1, '2023-04-02'::date) as d_month,
             dateadd(year, 1, '2023-04-02'::date) as d_year
         FROM example

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -298,7 +298,6 @@ def test_dateadd_date_cast(dcur: snowflake.connector.DictCursor):
         dateadd(week, 1, '2023-04-02'::date) as d_week,
         dateadd(month, 1, '2023-04-02'::date) as d_month,
         dateadd(year, 1, '2023-04-02'::date) as d_year
-    FROM example
     """
 
     dcur.execute(q)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -138,7 +138,6 @@ def test_dateadd_date_cast() -> None:
         == "SELECT col + INTERVAL 3 DAY AS D"
     )
 
-
     # WEEk
     assert (
         sqlglot.parse_one("SELECT DATEADD(WEEK, 3, '2023-03-03'::DATE) as D", read="snowflake")
@@ -203,7 +202,6 @@ def test_dateadd_date_cast() -> None:
         == "SELECT col + INTERVAL 3 MONTH AS D"
     )
 
-
     # YEAR
     assert (
         sqlglot.parse_one("SELECT DATEADD(YEAR, 3, '2023-03-03'::DATE) as D", read="snowflake")
@@ -235,8 +233,6 @@ def test_dateadd_date_cast() -> None:
         .sql(dialect="duckdb")
         == "SELECT col + INTERVAL 3 YEAR AS D"
     )
-
-
 
 
 def test_extract_comment_on_columns() -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,6 +10,7 @@ from fakesnow.transforms import (
     array_agg_within_group,
     array_size,
     create_database,
+    dateadd_date_cast,
     describe_table,
     drop_schema_cascade,
     extract_comment_on_columns,
@@ -102,6 +103,140 @@ def test_drop_schema_cascade() -> None:
     assert (
         sqlglot.parse_one("drop schema schema1").transform(drop_schema_cascade).sql() == "DROP schema schema1 CASCADE"
     )
+
+
+def test_dateadd_date_cast() -> None:
+    # DAY
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(DAY, 3, '2023-03-03'::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-03-03' AS DATE) + INTERVAL 3 DAY AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one(
+            "SELECT DATEADD(day, col-1, CAST('2023-04-02' AS DATE))",
+            read="snowflake",
+        )
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-04-02' AS DATE) + INTERVAL (col - 1) DAY AS DATE)"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(DAY, 3, col::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST(col AS DATE) + INTERVAL 3 DAY AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(DAY, 3, col) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 DAY AS D"
+    )
+
+
+    # WEEk
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(WEEK, 3, '2023-03-03'::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-03-03' AS DATE) + (7 * INTERVAL 3 DAY) AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one(
+            "SELECT DATEADD(week, col-1, CAST('2023-04-02' AS DATE))",
+            read="snowflake",
+        )
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-04-02' AS DATE) + (7 * INTERVAL (col - 1) DAY) AS DATE)"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(week, 3, col::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST(col AS DATE) + (7 * INTERVAL 3 DAY) AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(week, 3, col) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT col + (7 * INTERVAL 3 DAY) AS D"
+    )
+
+    # MONTH
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(MONTH, 3, '2023-03-03'::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-03-03' AS DATE) + INTERVAL 3 MONTH AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one(
+            "SELECT DATEADD(month, col-1, CAST('2023-04-02' AS DATE))",
+            read="snowflake",
+        )
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-04-02' AS DATE) + INTERVAL (col - 1) MONTH AS DATE)"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(month, 3, col::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST(col AS DATE) + INTERVAL 3 MONTH AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(month, 3, col) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 MONTH AS D"
+    )
+
+
+    # YEAR
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(YEAR, 3, '2023-03-03'::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-03-03' AS DATE) + INTERVAL 3 YEAR AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one(
+            "SELECT DATEADD(year, col-1, CAST('2023-04-02' AS DATE))",
+            read="snowflake",
+        )
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST('2023-04-02' AS DATE) + INTERVAL (col - 1) YEAR AS DATE)"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(YEAR, 3, col::DATE) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(CAST(col AS DATE) + INTERVAL 3 YEAR AS DATE) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(YEAR, 3, col) as D", read="snowflake")
+        .transform(dateadd_date_cast)
+        .sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 YEAR AS D"
+    )
+
+
 
 
 def test_extract_comment_on_columns() -> None:


### PR DESCRIPTION
Snowflake's [`DATEADD(<date_or_time_part>, <value>, <date_or_time_expr> )`](https://docs.snowflake.com/en/sql-reference/functions/dateadd) seems to return `DATE` if;
* `date_or_time_expr` is `DATE` typed.
* and `date_or_time_part` is either `DAY`, `WEEK`, `MONTH`, `YEAR`.

```sql
with
    t1 as(
        select '2023-03-01' as literal, '2023-03-01'::date as date_valued
    )
select 
    dateadd('day', 3, literal::DATE) as c1, SYSTEM$TYPEOF(c1),
    dateadd('day', 3, date_valued) as c2, SYSTEM$TYPEOF(c2),
    
    dateadd('week', 3, literal::DATE) as c3, SYSTEM$TYPEOF(c3),
    dateadd('week', 3, date_valued) as c4, SYSTEM$TYPEOF(c4),

    dateadd('month', 3, literal::DATE) as c5, SYSTEM$TYPEOF(c5),
    dateadd('month', 3, date_valued) as c6, SYSTEM$TYPEOF(c6),

    dateadd('year', 3, literal::DATE) as c7, SYSTEM$TYPEOF(c7),
    dateadd('year', 3, date_valued) as c8, SYSTEM$TYPEOF(c8)
from t1
;
```

|     C1     | SYSTEM$TYPEOF(C1) |     C2     | SYSTEM$TYPEOF(C2) |     C3     | SYSTEM$TYPEOF(C3) |
|------------|-------------------|------------|-------------------|------------|-------------------|
| 2023-03-04 | DATE[SB4]         | 2023-03-04 | DATE[SB4]         | 2023-03-22 | DATE[SB4]         |

|     C4     | SYSTEM$TYPEOF(C4) |     C5     | SYSTEM$TYPEOF(C5) |     C6     | SYSTEM$TYPEOF(C6) |
|------------|-------------------|------------|-------------------|------------|-------------------|
| 2023-03-22 | DATE[SB4]         | 2023-06-01 | DATE[SB4]         | 2023-06-01 | DATE[SB4]         |

|     C7     | SYSTEM$TYPEOF(C7) |     C8     | SYSTEM$TYPEOF(C8) |
|------------|-------------------|------------|-------------------|
| 2026-03-01 | DATE[SB4]         | 2026-03-01 | DATE[SB4]         |

Since there's no way to ensure if a column's type is `DATE` in transformation phase, this transform casts result to `DATE` if only the operand has an explicit `DATE` cast with units known to return `DATE`.

```sql
-- snowflake
select dateadd('day', 3, '2023-03-01'::DATE);
-- 2023-03-04


-- duckdb, default
select CAST('2023-03-01' AS DATE) + INTERVAL 3 DAY;
-- 2023-03-04 00:00:00


-- duckdb, with transformation
select CAST(CAST('2023-03-01' AS DATE) + INTERVAL 3 DAY AS DATE);
-- 2023-03-04
```
