### PR TITLE
feat: cast string literals to timestamp in dateadd

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -198,6 +198,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.identifier)
             .transform(transforms.array_agg_within_group)
             .transform(transforms.array_agg_to_json)
+            .transform(transforms.dateadd_string_literal_timestamp_cast)
             .transform(lambda e: transforms.show_schemas(e, self._conn.database))
             .transform(lambda e: transforms.show_objects_tables(e, self._conn.database))
             # TODO collapse into a single show_keys function

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -184,7 +184,7 @@ def dateadd_string_literal_timestamp_cast(expression: exp.Expression) -> exp.Exp
         "this",
         exp.Cast(
             this=expression.this,
-            # TODO(selman): TIMESTAMP_TZ OR NTZ?
+            # TODO: support TIMESTAMP_TYPE_MAPPING of TIMESTAMP_LTZ/TZ
             to=exp.DataType(this=exp.DataType.Type.TIMESTAMP, nested=False, prefix=False),
         ),
     )

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -176,18 +176,14 @@ def dateadd_string_literal_timestamp_cast(expression: exp.Expression) -> exp.Exp
     if not isinstance(expression, exp.DateAdd):
         return expression
 
-    dateadd = expression
-
-    if not isinstance(dateadd.this, exp.Literal) or not dateadd.this.is_string:
+    if not isinstance(expression.this, exp.Literal) or not expression.this.is_string:
         return expression
 
-    string_literal = dateadd.this
-
-    new_dateadd = dateadd.copy()
+    new_dateadd = expression.copy()
     new_dateadd.set(
         "this",
         exp.Cast(
-            this=string_literal,
+            this=expression.this,
             # TODO(selman): TIMESTAMP_TZ OR NTZ?
             to=exp.DataType(this=exp.DataType.Type.TIMESTAMP, nested=False, prefix=False),
         ),

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -290,54 +290,52 @@ def test_connect_with_non_existent_db_or_schema(_fakesnow_no_auto_create: None):
         assert conn.schema == "JAFFLES"
 
 
-def test_dateadd_string_literal_timestamp_cast(conn: snowflake.connector.SnowflakeConnection):
-    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
-        q = """
-        SELECT
-          DATEADD('MINUTE', 3, '2023-04-02') AS D_MINUTE,
-          DATEADD('HOUR', 3, '2023-04-02') AS D_HOUR,
-          DATEADD('DAY', 3, '2023-04-02') AS D_DAY,
-          DATEADD('WEEK', 3, '2023-04-02') AS D_WEEK,
-          DATEADD('MONTH', 3, '2023-04-02') AS D_MONTH,
-          DATEADD('YEAR', 3, '2023-04-02') AS D_YEAR
-        ;
-        """
-        cur.execute(q)
+def test_dateadd_string_literal_timestamp_cast(dcur: snowflake.connector.cursor.DictCursor):
+    q = """
+    SELECT
+        DATEADD('MINUTE', 3, '2023-04-02') AS D_MINUTE,
+        DATEADD('HOUR', 3, '2023-04-02') AS D_HOUR,
+        DATEADD('DAY', 3, '2023-04-02') AS D_DAY,
+        DATEADD('WEEK', 3, '2023-04-02') AS D_WEEK,
+        DATEADD('MONTH', 3, '2023-04-02') AS D_MONTH,
+        DATEADD('YEAR', 3, '2023-04-02') AS D_YEAR
+    ;
+    """
+    dcur.execute(q)
 
-        assert cur.fetchall() == [
-            {
-                "D_MINUTE": datetime.datetime(2023, 4, 2, 0, 3),
-                "D_HOUR": datetime.datetime(2023, 4, 2, 3, 0),
-                "D_DAY": datetime.datetime(2023, 4, 5, 0, 0),
-                "D_WEEK": datetime.datetime(2023, 4, 23, 0, 0),
-                "D_MONTH": datetime.datetime(2023, 7, 2, 0, 0),
-                "D_YEAR": datetime.datetime(2026, 4, 2, 0, 0),
-            }
-        ]
+    assert dcur.fetchall() == [
+        {
+            "D_MINUTE": datetime.datetime(2023, 4, 2, 0, 3),
+            "D_HOUR": datetime.datetime(2023, 4, 2, 3, 0),
+            "D_DAY": datetime.datetime(2023, 4, 5, 0, 0),
+            "D_WEEK": datetime.datetime(2023, 4, 23, 0, 0),
+            "D_MONTH": datetime.datetime(2023, 7, 2, 0, 0),
+            "D_YEAR": datetime.datetime(2026, 4, 2, 0, 0),
+        }
+    ]
 
-    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
-        q = """
-        SELECT
-          DATEADD('MINUTE', 3, '2023-04-02 01:15:00') AS DT_MINUTE,
-          DATEADD('HOUR', 3, '2023-04-02 01:15:00') AS DT_HOUR,
-          DATEADD('DAY', 3, '2023-04-02 01:15:00') AS DT_DAY,
-          DATEADD('WEEK', 3, '2023-04-02 01:15:00') AS DT_WEEK,
-          DATEADD('MONTH', 3, '2023-04-02 01:15:00') AS DT_MONTH,
-          DATEADD('YEAR', 3, '2023-04-02 01:15:00') AS DT_YEAR
-        ;
-        """
-        cur.execute(q)
+    q = """
+    SELECT
+        DATEADD('MINUTE', 3, '2023-04-02 01:15:00') AS DT_MINUTE,
+        DATEADD('HOUR', 3, '2023-04-02 01:15:00') AS DT_HOUR,
+        DATEADD('DAY', 3, '2023-04-02 01:15:00') AS DT_DAY,
+        DATEADD('WEEK', 3, '2023-04-02 01:15:00') AS DT_WEEK,
+        DATEADD('MONTH', 3, '2023-04-02 01:15:00') AS DT_MONTH,
+        DATEADD('YEAR', 3, '2023-04-02 01:15:00') AS DT_YEAR
+    ;
+    """
+    dcur.execute(q)
 
-        assert cur.fetchall() == [
-            {
-                "DT_MINUTE": datetime.datetime(2023, 4, 2, 1, 18),
-                "DT_HOUR": datetime.datetime(2023, 4, 2, 4, 15),
-                "DT_DAY": datetime.datetime(2023, 4, 5, 1, 15),
-                "DT_WEEK": datetime.datetime(2023, 4, 23, 1, 15),
-                "DT_MONTH": datetime.datetime(2023, 7, 2, 1, 15),
-                "DT_YEAR": datetime.datetime(2026, 4, 2, 1, 15),
-            }
-        ]
+    assert dcur.fetchall() == [
+        {
+            "DT_MINUTE": datetime.datetime(2023, 4, 2, 1, 18),
+            "DT_HOUR": datetime.datetime(2023, 4, 2, 4, 15),
+            "DT_DAY": datetime.datetime(2023, 4, 5, 1, 15),
+            "DT_WEEK": datetime.datetime(2023, 4, 23, 1, 15),
+            "DT_MONTH": datetime.datetime(2023, 7, 2, 1, 15),
+            "DT_YEAR": datetime.datetime(2026, 4, 2, 1, 15),
+        }
+    ]
 
 
 def test_current_database_schema(conn: snowflake.connector.SnowflakeConnection):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -290,6 +290,56 @@ def test_connect_with_non_existent_db_or_schema(_fakesnow_no_auto_create: None):
         assert conn.schema == "JAFFLES"
 
 
+def test_dateadd_string_literal_timestamp_cast(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
+        q = """
+        SELECT
+          DATEADD('MINUTE', 3, '2023-04-02') AS D_MINUTE,
+          DATEADD('HOUR', 3, '2023-04-02') AS D_HOUR,
+          DATEADD('DAY', 3, '2023-04-02') AS D_DAY,
+          DATEADD('WEEK', 3, '2023-04-02') AS D_WEEK,
+          DATEADD('MONTH', 3, '2023-04-02') AS D_MONTH,
+          DATEADD('YEAR', 3, '2023-04-02') AS D_YEAR
+        ;
+        """
+        cur.execute(q)
+
+        assert cur.fetchall() == [
+            {
+                "D_MINUTE": datetime.datetime(2023, 4, 2, 0, 3),
+                "D_HOUR": datetime.datetime(2023, 4, 2, 3, 0),
+                "D_DAY": datetime.datetime(2023, 4, 5, 0, 0),
+                "D_WEEK": datetime.datetime(2023, 4, 23, 0, 0),
+                "D_MONTH": datetime.datetime(2023, 7, 2, 0, 0),
+                "D_YEAR": datetime.datetime(2026, 4, 2, 0, 0),
+            }
+        ]
+
+    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
+        q = """
+        SELECT
+          DATEADD('MINUTE', 3, '2023-04-02 01:15:00') AS DT_MINUTE,
+          DATEADD('HOUR', 3, '2023-04-02 01:15:00') AS DT_HOUR,
+          DATEADD('DAY', 3, '2023-04-02 01:15:00') AS DT_DAY,
+          DATEADD('WEEK', 3, '2023-04-02 01:15:00') AS DT_WEEK,
+          DATEADD('MONTH', 3, '2023-04-02 01:15:00') AS DT_MONTH,
+          DATEADD('YEAR', 3, '2023-04-02 01:15:00') AS DT_YEAR
+        ;
+        """
+        cur.execute(q)
+
+        assert cur.fetchall() == [
+            {
+                "DT_MINUTE": datetime.datetime(2023, 4, 2, 1, 18),
+                "DT_HOUR": datetime.datetime(2023, 4, 2, 4, 15),
+                "DT_DAY": datetime.datetime(2023, 4, 5, 1, 15),
+                "DT_WEEK": datetime.datetime(2023, 4, 23, 1, 15),
+                "DT_MONTH": datetime.datetime(2023, 7, 2, 1, 15),
+                "DT_YEAR": datetime.datetime(2026, 4, 2, 1, 15),
+            }
+        ]
+
+
 def test_current_database_schema(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
         cur.execute("select current_database(), current_schema()")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,6 +10,7 @@ from fakesnow.transforms import (
     array_agg_within_group,
     array_size,
     create_database,
+    dateadd_string_literal_timestamp_cast,
     describe_table,
     drop_schema_cascade,
     extract_comment_on_columns,
@@ -101,6 +102,22 @@ def test_describe_table() -> None:
 def test_drop_schema_cascade() -> None:
     assert (
         sqlglot.parse_one("drop schema schema1").transform(drop_schema_cascade).sql() == "DROP schema schema1 CASCADE"
+    )
+
+
+def test_dateadd_string_literal_timestamp_cast() -> None:
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(DAY, 3, '2023-03-03') as D", read="snowflake")
+        .transform(dateadd_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST('2023-03-03' AS TIMESTAMP) + INTERVAL 3 DAY AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEADD(MONTH, 3, '2023-03-03') as D", read="snowflake")
+        .transform(dateadd_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT CAST('2023-03-03' AS TIMESTAMP) + INTERVAL 3 MONTH AS D"
     )
 
 


### PR DESCRIPTION
Snowflake -again- seems to cast string literal in `DATEADD`  to `TIMESTAMP_LTZ` or `TIMESTAMP_NTZ` depending on `TIMESTAMP_TYPE_MAPPING` session parameter.

```sql
select
  dateadd('day', 3, '2023-04-02') as c1, SYSTEM$TYPEOF(c1),
  dateadd('week', 3, '2023-04-02') as c3, SYSTEM$TYPEOF(c3),
  dateadd('month', 3, '2023-04-02') as c5, SYSTEM$TYPEOF(c5),
  dateadd('year', 3, '2023-04-02') as c7, SYSTEM$TYPEOF(c7),
;
```

|              C1               |   SYSTEM$TYPEOF(C1)    |
|-------------------------------|------------------------|
| 2023-04-05 00:00:00.000 +0000 | TIMESTAMP_LTZ(9)[SB16] |

|              C3               |   SYSTEM$TYPEOF(C3)    |
|-------------------------------|------------------------|
| 2023-04-23 00:00:00.000 +0000 | TIMESTAMP_LTZ(9)[SB16] |

|              C5               |   SYSTEM$TYPEOF(C5)    |
|-------------------------------|------------------------|
| 2023-07-02 00:00:00.000 +0000 | TIMESTAMP_LTZ(9)[SB16] |

|              C7               |   SYSTEM$TYPEOF(C7)    |
|-------------------------------|------------------------|
| 2026-04-02 00:00:00.000 +0000 | TIMESTAMP_LTZ(9)[SB16] |


Here seems to me we can cast the operand to `TIMESTAMP` if it is a string literal to achieve similar behaviour.

But I'm a little bit concerned on `TIMESTAMP` as DuckDB is quite picky operations between `TIMESTAMP` and `TIMESTAMP WITH TIMEZONE`. Like; `CURRENT_TIMESTAMP` returns `TIMESTAMP WITH TIMEZONE` and `DATE_DIFF` expects either operands to be same typed. I saw that `to_timestamp` transformation casts to `TIMESTAMP` and went with it.

