### PR TITLE
feat: add timeadd as an alias for dateadd

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -182,6 +182,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.regex_replace)
             .transform(transforms.regex_substr)
             .transform(transforms.values_columns)
+            .transform(transforms.timeadd)
             .transform(transforms.to_date)
             .transform(transforms.to_decimal)
             .transform(transforms.to_timestamp_ntz)

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -879,6 +879,32 @@ def timestamp_ntz_ns(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
+def timeadd(expression: exp.Expression) -> exp.Expression:
+    """TIMEADD is an alias for DATEADD
+    See: https://docs.snowflake.com/en/sql-reference/functions/timeadd
+    """
+    if not (
+        isinstance(expression, exp.Anonymous)
+        and isinstance(expression.this, str)
+        and expression.this.upper() == "TIMEADD"
+    ):
+        return expression
+
+    if len(expression.expressions) != 3:
+        return expression
+
+    unit, value, date = expression.expressions.copy()
+
+    if isinstance(unit, exp.Literal):
+        unit = exp.Var(this=unit.this.upper())
+    elif isinstance(unit, exp.Column) and isinstance(unit.this, exp.Identifier):
+        unit = exp.Var(this=unit.this.this.upper())
+    else:
+        return expression
+
+    return exp.DateAdd(this=date, expression=value, unit=unit)
+
+
 # sqlglot.parse_one("create table example(date TIMESTAMP_NTZ(9));", read="snowflake")
 def semi_structured_types(expression: exp.Expression) -> exp.Expression:
     """Convert OBJECT, ARRAY, and VARIANT types to duckdb compatible types.

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1154,6 +1154,68 @@ def test_timestamp_to_date(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [(datetime.date(1970, 1, 1), datetime.date(1970, 1, 1), datetime.date(2024, 1, 26))]
 
 
+def test_timeadd(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
+        cur.execute("create table t1(d timestamp)")
+        cur.execute("insert into t1 values ('2024-01-26 12:00:00')")
+
+        cur.execute("""
+            SELECT
+              timeadd(second, 1, d) as d_second,
+              timeadd(minute, 1, d) as d_minute,
+              timeadd(hour, 1, d) as d_hour,
+              timeadd(day, 1, d) as d_day,
+              timeadd(week, 1, d) as d_week,
+              timeadd(month, 1, d) as d_month,
+              timeadd(year, 1, d) as d_year
+            FROM t1
+            """)
+
+        assert cur.fetchall() == [
+            {
+                "D_SECOND": datetime.datetime(2024, 1, 26, 12, 0, 1),
+                "D_MINUTE": datetime.datetime(2024, 1, 26, 12, 1, 0),
+                "D_HOUR": datetime.datetime(2024, 1, 26, 13, 0, 0),
+                "D_DAY": datetime.datetime(2024, 1, 27, 12, 0, 0),
+                "D_WEEK": datetime.datetime(2024, 2, 2, 12, 0, 0),
+                "D_MONTH": datetime.datetime(2024, 2, 26, 12, 0, 0),
+                "D_YEAR": datetime.datetime(2025, 1, 26, 12, 0, 0),
+            }
+        ]
+
+    with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
+        cur.execute("create table t2(d timestamp)")
+        cur.execute("insert into t2 values ('2024-01-26 12:00:00')")
+
+        cur.execute("""
+            SELECT
+              timeadd('second', 1, d) as d_second,
+              timeadd('minute', 1, d) as d_minute,
+              timeadd('hour', 1, d) as d_hour,
+              timeadd('day', 1, d) as d_day,
+              timeadd('week', 1, d) as d_week,
+              timeadd('month', 1, d) as d_month,
+              timeadd('year', 1, d) as d_year
+            FROM t1
+            """)
+
+        assert cur.fetchall() == [
+            {
+                "D_SECOND": datetime.datetime(2024, 1, 26, 12, 0, 1),
+                "D_MINUTE": datetime.datetime(2024, 1, 26, 12, 1, 0),
+                "D_HOUR": datetime.datetime(2024, 1, 26, 13, 0, 0),
+                "D_DAY": datetime.datetime(2024, 1, 27, 12, 0, 0),
+                "D_WEEK": datetime.datetime(2024, 2, 2, 12, 0, 0),
+                "D_MONTH": datetime.datetime(2024, 2, 26, 12, 0, 0),
+                "D_YEAR": datetime.datetime(2025, 1, 26, 12, 0, 0),
+            }
+        ]
+
+    # TODO: Following PR's would require new test cases
+    # * https://github.com/tekumara/fakesnow/pull/71
+    # * https://github.com/tekumara/fakesnow/pull/72
+
+
 def test_to_decimal(cur: snowflake.connector.cursor.SnowflakeCursor):
     # see https://docs.snowflake.com/en/sql-reference/functions/to_decimal#examples
     cur.execute("create or replace table number_conv(expr varchar);")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -32,6 +32,7 @@ from fakesnow.transforms import (
     show_objects_tables,
     show_schemas,
     tag,
+    timeadd,
     timestamp_ntz_ns,
     to_date,
     to_decimal,
@@ -344,6 +345,42 @@ def test_timestamp_ntz_ns() -> None:
         .transform(timestamp_ntz_ns)
         .sql(dialect="duckdb")
         == "CREATE TABLE table1 (ts TIMESTAMP)"
+    )
+
+
+def test_timeadd() -> None:
+    assert (
+        sqlglot.parse_one("SELECT timeadd(hour, 3, col)", read="snowflake").transform(timeadd).sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 HOUR"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT timeadd(HOUR, 3, col)", read="snowflake").transform(timeadd).sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 HOUR"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT timeadd('hour', 3, col)", read="snowflake").transform(timeadd).sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 HOUR"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT timeadd('HOUR', 3, col)", read="snowflake").transform(timeadd).sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 HOUR"
+    )
+
+    assert (
+        sqlglot.parse_one("""SELECT timeadd("HOUR", 3, col)""", read="snowflake")
+        .transform(timeadd)
+        .sql(dialect="duckdb")
+        == "SELECT col + INTERVAL 3 HOUR"
+    )
+
+    assert (
+        sqlglot.parse_one("""SELECT timeadd(week, 3, '2023-01-01')""", read="snowflake")
+        .transform(timeadd)
+        .sql(dialect="duckdb")
+        == "SELECT '2023-01-01' + (7 * INTERVAL 3 DAY)"
     )
 
 


### PR DESCRIPTION
`sqlglot~=21.2.0` does not support `timeadd` for Snowflake, this transform simply tries to convert it to `DateAdd`.

[sqlglot v23.1.0](https://github.com/tobymao/sqlglot/blob/main/CHANGELOG.md#v2310---2024-03-26) adds `timeadd/addtime` with https://github.com/tobymao/sqlglot/pull/3180/files but upgrade would require changes on other transforms like `to_timestamp` and ones with json extraction.