### PR TITLE
fix: remove only null key/values in object_construct

### DIFF
--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -541,12 +541,26 @@ def object_construct(expression: exp.Expression) -> exp.Expression:
     """
 
     if isinstance(expression, exp.Struct):
-        # remove expressions containing NULL
-        for enull in expression.find_all(exp.Null):
-            if enull.parent:
-                enull.parent.pop()
+        non_null_expressions = []
+        for e in expression.expressions:
+            if not (isinstance(e, exp.EQ)):
+                non_null_expressions.append(e)
+                continue
 
-        return exp.Anonymous(this="TO_JSON", expressions=[expression])
+            left = e.left
+            right = e.right
+
+            left_is_null = isinstance(left, exp.Null)
+            right_is_null = isinstance(right, exp.Null)
+
+            if left_is_null or right_is_null:
+                continue
+
+            non_null_expressions.append(e)
+
+        new_struct = expression.copy()
+        new_struct.set("expressions", non_null_expressions)
+        return exp.Anonymous(this="TO_JSON", expressions=[new_struct])
 
     return expression
 

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -543,7 +543,7 @@ def object_construct(expression: exp.Expression) -> exp.Expression:
     if isinstance(expression, exp.Struct):
         non_null_expressions = []
         for e in expression.expressions:
-            if not (isinstance(e, exp.EQ)):
+            if not (isinstance(e, exp.PropertyEQ)):
                 non_null_expressions.append(e)
                 continue
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -289,6 +289,16 @@ def test_object_construct() -> None:
         == "SELECT TO_JSON({'a': 1, 'b': 'BBBB', 'd': JSON('NULL')})"
     )
 
+    assert (
+        sqlglot.parse_one(
+            "SELECT OBJECT_CONSTRUCT( 'k1', 'v1', 'k2', CASE WHEN ZEROIFNULL(col) + 1 >= 2 THEN 'v2' ELSE NULL END, 'k3', 'v3')",  # noqa: E501
+            read="snowflake",
+        )
+        .transform(object_construct)
+        .sql(dialect="duckdb")
+        == "SELECT TO_JSON({'k1': 'v1', 'k2': CASE WHEN CASE WHEN col IS NULL THEN 0 ELSE col END + 1 >= 2 THEN 'v2' ELSE NULL END, 'k3': 'v3'})"  # noqa: E501
+    )
+
 
 def test_random() -> None:
     e = sqlglot.parse_one("select random(420)").transform(random)


### PR DESCRIPTION
sqlglot transforms Snowlake's `zeroifnull` to `case when .. is null ...` statement. In `object_construct`, removing every `NULL` expression generates an unexpected query;

```sql
-- snowflake
SELECT OBJECT_CONSTRUCT( 'k1', 'v1', 'k2', CASE WHEN ZEROIFNULL(col) + 1 >= 2 THEN 'v2' ELSE NULL END, 'k3', 'v3')

-- before
SELECT TO_JSON({'k1': 'v1', 'k2': , 'k3': 'v3'})

-- after
SELECT TO_JSON({'k1': 'v1', 'k2': CASE WHEN CASE WHEN col IS NULL THEN 0 ELSE col END + 1 >= 2 THEN 'v2' ELSE NULL END, 'k3': 'v3'})
--                                          |------zeroifnull(col)-----|

```

AFAIS `Struct` only contains `EQ` expressions on `object_construct`. Instead of removing every `NULL` we can just remove `NULL` keyed/valued `EQ` expressions.