### PR TITLE
chore(deps): bump sqlglot to 23.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "duckdb~=0.10.0",
     "pyarrow",
     "snowflake-connector-python",
-    "sqlglot~=21.2.0",
+    "sqlglot~=23.3.0",
 ]
 
 [project.urls]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -501,6 +501,7 @@ def test_to_number_decimal() -> None:
             dialect="duckdb"
         )
 
+
 def test_to_number_numeric() -> None:
     assert (
         sqlglot.parse_one("SELECT to_numeric('100')", read="snowflake").transform(to_decimal).sql(dialect="duckdb")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1,10 +1,12 @@
 from pathlib import Path
 
+import pytest
 import sqlglot
 from sqlglot import exp
 
 from fakesnow.transforms import (
     SUCCESS_NOP,
+    _get_to_number_args,
     array_size,
     create_database,
     describe_table,
@@ -394,6 +396,143 @@ def test_use() -> None:
         sqlglot.parse_one("use schema foo.bar").transform(set_schema, current_database="marts").sql()
         == "SET schema = 'foo.bar'"
     )
+
+
+def test__get_to_number_args() -> None:
+    e = sqlglot.parse_one("to_number('100')", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (None, None, None)
+
+    e = sqlglot.parse_one("to_number('100', 10)", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (None, exp.Literal(this="10", is_string=False), None)
+
+    e = sqlglot.parse_one("to_number('100', 10,2)", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (
+        None,
+        exp.Literal(this="10", is_string=False),
+        exp.Literal(this="2", is_string=False),
+    )
+
+    e = sqlglot.parse_one("to_number('100', 'TM9')", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (exp.Literal(this="TM9", is_string=True), None, None)
+
+    e = sqlglot.parse_one("to_number('100', 'TM9', 10)", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (
+        exp.Literal(this="TM9", is_string=True),
+        exp.Literal(this="10", is_string=False),
+        None,
+    )
+
+    e = sqlglot.parse_one("to_number('100', 'TM9', 10, 2)", read="snowflake")
+    assert isinstance(e, exp.ToNumber)
+    assert _get_to_number_args(e) == (
+        exp.Literal(this="TM9", is_string=True),
+        exp.Literal(this="10", is_string=False),
+        exp.Literal(this="2", is_string=False),
+    )
+
+
+def test_to_number() -> None:
+    assert (
+        sqlglot.parse_one("SELECT to_number('100')", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(38, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_number('100', 10)", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_number('100', 10,2)", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 2))"
+    )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_number('100', 'TM9')", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_number('100', 'TM9', 10)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_number('100', 'TM9', 10, 2)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+
+def test_to_number_decimal() -> None:
+    assert (
+        sqlglot.parse_one("SELECT to_decimal('100')", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(38, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_decimal('100', 10)", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_decimal('100', 10,2)", read="snowflake")
+        .transform(to_decimal)
+        .sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 2))"
+    )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_decimal('100', 'TM9')", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_decimal('100', 'TM9', 10)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_decimal('100', 'TM9', 10, 2)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+def test_to_number_numeric() -> None:
+    assert (
+        sqlglot.parse_one("SELECT to_numeric('100')", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(38, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_numeric('100', 10)", read="snowflake").transform(to_decimal).sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 0))"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT to_numeric('100', 10,2)", read="snowflake")
+        .transform(to_decimal)
+        .sql(dialect="duckdb")
+        == "SELECT CAST('100' AS DECIMAL(10, 2))"
+    )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_numeric('100', 'TM9')", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_numeric('100', 'TM9', 10)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
+
+    with pytest.raises(NotImplementedError):
+        sqlglot.parse_one("SELECT to_numeric('100', 'TM9', 10, 2)", read="snowflake").transform(to_decimal).sql(
+            dialect="duckdb"
+        )
 
 
 def test_upper_case_unquoted_identifiers() -> None:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -245,7 +245,7 @@ def test_json_extract_precedence() -> None:
         )
         .transform(json_extract_precedence)
         .sql(dialect="duckdb")
-        == """SELECT {'K1': {'K2': 1}} AS col WHERE (col -> '$.K1' -> '$.K2') > 0"""
+        == """SELECT {'K1': {'K2': 1}} AS col WHERE (col -> '$.K1.K2') > 0"""
     )
 
 


### PR DESCRIPTION
* nested json accesses combined into a single path;
```diff
--- old
+++ new
@@ -1 +1 @@
-col -> '$.K1' -> '$.K2'
+col -> '$.K1.K2'
```
* `TO_NUMBER(...)` parsed as `exp.ToNumber`, but AST is a little weird for Snowflake and it is not generated as `DECIMAL` in DuckDB but as `DOUBLE`;
https://github.com/tobymao/sqlglot/blob/2a3a5cdc/sqlglot/dialects/duckdb.py#L368-L368
https://github.com/tobymao/sqlglot/blob/2a3a5cdcffe39d42153b3e960a580d084a27c0eb/sqlglot/generator.py#L3315-L3326


```python
# to_number('100')
ToNumber(
  this=Literal(this=100, is_string=True))
```


```python
# to_number('100', 10)
ToNumber(
  this=Literal(this=100, is_string=True),
  format=Literal(this=10, is_string=False))
```


```python
# to_number('100', 10,2)
ToNumber(
  this=Literal(this=100, is_string=True),
  format=Literal(this=10, is_string=False),
  precision=Literal(this=2, is_string=False))
```


```python
# to_number('100', 'TM9')
ToNumber(
  this=Literal(this=100, is_string=True),
  format=Literal(this=TM9, is_string=True))
```


```python
# to_number('100', 'TM9', 10)
ToNumber(
  this=Literal(this=100, is_string=True),
  format=Literal(this=TM9, is_string=True),
  precision=Literal(this=10, is_string=False))
```


```python
# to_number('100', 'TM9', 10, 2)
ToNumber(
  this=Literal(this=100, is_string=True),
  format=Literal(this=TM9, is_string=True),
  precision=Literal(this=10, is_string=False),
  scale=Literal(this=2, is_string=False))
```

Seems like sqlglot only consider argument positions to decide whether they're format, precision or scale had to add some logic to extract correct arguments.

--------------

I've tested cases in https://github.com/tekumara/fakesnow/pull/73, they all pass.