### PR TITLE
fix(json extraction): only return string when casting to varchar

### DIFF
--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -566,6 +566,9 @@ def json_extract_cast_as_varchar(expression: exp.Expression) -> exp.Expression:
     """
     if (
         isinstance(expression, exp.Cast)
+        and (to := expression.to)
+        and isinstance(to, exp.DataType)
+        and to.this in {exp.DataType.Type.VARCHAR, exp.DataType.Type.TEXT}
         and (je := expression.this)
         and isinstance(je, exp.JSONExtract)
         and (path := je.expression)

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1450,6 +1450,17 @@ def test_values(conn: snowflake.connector.SnowflakeConnection):
         ]
 
 
+def test_json_extract_cast_as_varchar(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE TABLE example (j VARIANT)")
+    dcur.execute("""INSERT INTO example VALUES ('{"str": "100", "number" : 100}')""")
+
+    dcur.execute("SELECT j:str::varchar as c_str_varchar, j:number::varchar as c_num_varchar  FROM example")
+    assert dcur.fetchall() == [{"C_STR_VARCHAR": "100", "C_NUM_VARCHAR": "100"}]
+
+    dcur.execute("SELECT j:str::number as c_str_number, j:number::number as c_num_number  FROM example")
+    assert dcur.fetchall() == [{"C_STR_NUMBER": 100, "C_NUM_NUMBER": 100}]
+
+
 def test_write_pandas_quoted_column_names(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor(snowflake.connector.cursor.DictCursor) as dcur:
         # colunmn names with spaces

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1452,7 +1452,7 @@ def test_values(conn: snowflake.connector.SnowflakeConnection):
 
 def test_json_extract_cast_as_varchar(dcur: snowflake.connector.cursor.DictCursor):
     dcur.execute("CREATE TABLE example (j VARIANT)")
-    dcur.execute("""INSERT INTO example VALUES ('{"str": "100", "number" : 100}')""")
+    dcur.execute("""INSERT INTO example SELECT PARSE_JSON('{"str": "100", "number" : 100}')""")
 
     dcur.execute("SELECT j:str::varchar as c_str_varchar, j:number::varchar as c_num_varchar  FROM example")
     assert dcur.fetchall() == [{"C_STR_VARCHAR": "100", "C_NUM_VARCHAR": "100"}]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -446,6 +446,16 @@ def test_json_extract_cast_as_varchar() -> None:
         == """SELECT JSON('{"fruit":"banana"}') ->> '$.fruit'"""
     )
 
+    assert (
+        sqlglot.parse_one(
+            """select parse_json('{"fruit":"9000"}'):fruit::number""",
+            read="snowflake",
+        )
+        .transform(json_extract_cast_as_varchar)
+        .sql(dialect="duckdb")
+        == """SELECT CAST(JSON('{"fruit":"9000"}') -> '$.fruit' AS DECIMAL)"""
+    )
+
 
 def test_json_extract_precedence() -> None:
     assert (


### PR DESCRIPTION
Not sure if intentional but despite doc comment `Return raw unquoted string when casting json extraction to varchar`, `json_extract_cast_as_varchar` transforms all CASTs on JSON extraction to `VARCHAR`.

```sql
-- snowflake
select parse_json('{"fruit":"9000"}'):fruit::number

-- becomes in duckdb;
SELECT JSON('{"fruit":"9000"}') ->> '$.fruit'
```