### PR TITLE
fix: GET_PATH precedence for JSONExtractScalar

### DIFF
--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -580,7 +580,7 @@ def json_extract_precedence(expression: exp.Expression) -> exp.Expression:
 
     See https://github.com/tekumara/fakesnow/issues/53
     """
-    if isinstance(expression, exp.JSONExtract):
+    if isinstance(expression, (exp.JSONExtract, exp.JSONExtractScalar)):
         return exp.Paren(this=expression)
     return expression
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -797,7 +797,7 @@ def test_get_path_precedence(cur: snowflake.connector.cursor.SnowflakeCursor):
 
     cur.execute("create table example (col variant)")
 
-    cur.execute("""insert into example values ('{"K1": "a", "K2": "b"}')""")
+    cur.execute("""insert into example select parse_json('{"K1": "a", "K2": "b"}')""")
     cur.execute("select case when col:K1::VARCHAR = 'a' and col:K2::VARCHAR = 'b' then 'yes' end from example")
     assert cur.fetchall() == [("yes",)]
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -795,11 +795,10 @@ def test_get_path_precedence(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("select {'K1': {'K2': 1}} as col where col:K1:K2 > 0")
     assert indent(cur.fetchall()) == [('{\n  "K1": {\n    "K2": 1\n  }\n}',)]
 
-    cur.execute("create table example (col variant)")
-
-    cur.execute("""insert into example select parse_json('{"K1": "a", "K2": "b"}')""")
-    cur.execute("select case when col:K1::VARCHAR = 'a' and col:K2::VARCHAR = 'b' then 'yes' end from example")
-    assert cur.fetchall() == [("yes",)]
+    cur.execute(
+        """select parse_json('{"K1": "a", "K2": "b"}') as col, case when col:K1::VARCHAR = 'a' and col:K2::VARCHAR = 'b' then 'yes' end"""
+    )
+    assert indent(cur.fetchall()) == [('{\n  "K1": "a",\n  "K2": "b"\n}', "yes")]
 
 
 def test_get_result_batches(cur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -792,6 +792,15 @@ def test_get_path_precedence(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("select {'K1': {'K2': 1}} as col where col:K1:K2 > 0")
     assert indent(cur.fetchall()) == [('{\n  "K1": {\n    "K2": 1\n  }\n}',)]
 
+    cur.execute("select {'K1': {'K2': 1}} as col where col:K1:K2 > 0")
+    assert indent(cur.fetchall()) == [('{\n  "K1": {\n    "K2": 1\n  }\n}',)]
+
+    cur.execute("create table example (col variant)")
+
+    cur.execute("""insert into example values ('{"K1": "a", "K2": "b"}')""")
+    cur.execute("select case when col:K1::VARCHAR = 'a' and col:K2::VARCHAR = 'b' then 'yes' end from example")
+    assert cur.fetchall() == [("yes",)]
+
 
 def test_get_result_batches(cur: snowflake.connector.cursor.SnowflakeCursor):
     # no result set


### PR DESCRIPTION
I've encountered another precedence issue with json extract scalar this time;

```sql
select JSON('{"K1": "a", "K2": "b"}') as col, CASE WHEN COL ->> '$.K1' = 'a' AND COL ->> '$.K2' = 'b' THEN 'yes' END as r;
-- Error: Conversion Error: Failed to cast value to numerical: {"K1":"a","K2":"b"}

select JSON('{"K1": "a", "K2": "b"}') as col, CASE WHEN (COL ->> '$.K1') = 'a' AND (COL ->> '$.K2') = 'b' THEN 'yes' END as r;
-- ┌─────────────────────┬─────────┐
-- │         col         │    r    │
-- │        json         │ varchar │
-- ├─────────────────────┼─────────┤
-- │ {"K1":"a","K2":"b"} │ yes     │
-- └─────────────────────┴─────────┘

```
