### PR TITLE
feat: cast string literals to timestamp in datediff

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -198,6 +198,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.identifier)
             .transform(transforms.array_agg_within_group)
             .transform(transforms.array_agg_to_json)
+            .transform(transforms.datediff_string_literal_timestamp_cast)
             .transform(lambda e: transforms.show_schemas(e, self._conn.database))
             .transform(lambda e: transforms.show_objects_tables(e, self._conn.database))
             # TODO collapse into a single show_keys function

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -200,23 +200,24 @@ def datediff_string_literal_timestamp_cast(expression: exp.Expression) -> exp.Ex
     if not isinstance(expression, exp.DateDiff):
         return expression
 
-    datediff = expression
-    op1 = datediff.this.copy()
-    op2 = datediff.expression.copy()
+    op1 = expression.this.copy()
+    op2 = expression.expression.copy()
 
     if isinstance(op1, exp.Literal) and op1.is_string:
         op1 = exp.Cast(
             this=op1,
+            # TODO: support TIMESTAMP_TYPE_MAPPING of TIMESTAMP_LTZ/TZ
             to=exp.DataType(this=exp.DataType.Type.TIMESTAMP, nested=False, prefix=False),
         )
 
     if isinstance(op2, exp.Literal) and op2.is_string:
         op2 = exp.Cast(
             this=op2,
+            # TODO: support TIMESTAMP_TYPE_MAPPING of TIMESTAMP_LTZ/TZ
             to=exp.DataType(this=exp.DataType.Type.TIMESTAMP, nested=False, prefix=False),
         )
 
-    new_datediff = datediff.copy()
+    new_datediff = expression.copy()
     new_datediff.set("this", op1)
     new_datediff.set("expression", op2)
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -290,6 +290,21 @@ def test_connect_with_non_existent_db_or_schema(_fakesnow_no_auto_create: None):
         assert conn.schema == "JAFFLES"
 
 
+def test_datediff_string_literal_timestamp_cast(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("SELECT DATEDIFF(DAY, '2023-04-02', '2023-03-02') AS D")
+    assert cur.fetchall() == [(-31,)]
+
+    cur.execute("SELECT DATEDIFF(HOUR, '2023-04-02', '2023-03-02') AS D")
+    assert cur.fetchall() == [(-744,)]
+
+    cur.execute("SELECT DATEDIFF(week, '2023-04-02', '2023-03-02') AS D")
+    assert cur.fetchall() == [(-4,)]
+
+    # noop
+    cur.execute("select '2023-04-02'::timestamp as c1, '2023-03-02'::timestamp as c2, DATEDIFF(minute, c1, c2) AS D")
+    assert cur.fetchall() == [(datetime.datetime(2023, 4, 2, 0, 0), datetime.datetime(2023, 3, 2, 0, 0), -44640)]
+
+
 def test_current_database_schema(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
         cur.execute("select current_database(), current_schema()")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -10,6 +10,7 @@ from fakesnow.transforms import (
     array_agg_within_group,
     array_size,
     create_database,
+    datediff_string_literal_timestamp_cast,
     describe_table,
     drop_schema_cascade,
     extract_comment_on_columns,
@@ -101,6 +102,36 @@ def test_describe_table() -> None:
 def test_drop_schema_cascade() -> None:
     assert (
         sqlglot.parse_one("drop schema schema1").transform(drop_schema_cascade).sql() == "DROP schema schema1 CASCADE"
+    )
+
+
+def test_datediff_string_literal_timestamp_cast() -> None:
+    assert (
+        sqlglot.parse_one("SELECT DATEDIFF(DAY, somecolumn, '2023-04-02') AS D", read="snowflake")
+        .transform(datediff_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT DATE_DIFF('DAY', somecolumn, CAST('2023-04-02' AS TIMESTAMP)) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEDIFF(HOUR, '2023-04-02', somecolumn) AS D", read="snowflake")
+        .transform(datediff_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT DATE_DIFF('HOUR', CAST('2023-04-02' AS TIMESTAMP), somecolumn) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEDIFF(week, '2023-04-02', '2023-03-02') AS D", read="snowflake")
+        .transform(datediff_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT DATE_DIFF('WEEK', CAST('2023-04-02' AS TIMESTAMP), CAST('2023-03-02' AS TIMESTAMP)) AS D"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT DATEDIFF(minute, c1, c2) AS D", read="duckdb")
+        .transform(datediff_string_literal_timestamp_cast)
+        .sql(dialect="duckdb")
+        == "SELECT DATE_DIFF('MINUTE', c1, c2) AS D"
     )
 
 


### PR DESCRIPTION
Basically the same as https://github.com/tekumara/fakesnow/pull/72 but for `DATEDIFF`. 

Same concerns of the `DATEADD` change applies here;
> But I'm a little bit concerned on TIMESTAMP as DuckDB is quite picky operations between TIMESTAMP and TIMESTAMP WITH TIMEZONE. Like; CURRENT_TIMESTAMP returns TIMESTAMP WITH TIMEZONE and DATE_DIFF expects either operands to be same typed. I saw that to_timestamp transformation casts to TIMESTAMP and went with it.