### PR TITLE
fix: ALTER TABLE result output

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -297,6 +297,9 @@ class FakeSnowflakeCursor:
             elif cmd == "CREATE TABLE" and ident:
                 result_sql = SQL_CREATED_TABLE.substitute(name=ident)
 
+            elif cmd.startswith("ALTER") and ident:
+                result_sql = SQL_SUCCESS
+
             elif cmd == "CREATE VIEW" and ident:
                 result_sql = SQL_CREATED_VIEW.substitute(name=ident)
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -589,9 +589,12 @@ def test_description_create_drop_schema(dcur: snowflake.connector.cursor.DictCur
     assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
 
 
-def test_description_create_drop_table(dcur: snowflake.connector.cursor.DictCursor):
+def test_description_create_alter_drop_table(dcur: snowflake.connector.cursor.DictCursor):
     dcur.execute("create table example (x int)")
     assert dcur.fetchall() == [{"status": "Table EXAMPLE successfully created."}]
+    assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
+    dcur.execute("alter table example add column name varchar(20)")
+    assert dcur.fetchall() == [{"status": "Statement executed successfully."}]
     assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip
     dcur.execute("drop table example")
     assert dcur.fetchall() == [{"status": "EXAMPLE successfully dropped."}]

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -44,3 +44,9 @@ def test_reflect(snowflake_engine: Engine):
 
         assert result
         assert result.fetchall() == [(1, "one")]
+
+
+def test_alter_table(snowflake_engine: Engine):
+    with snowflake_engine.connect() as conn:
+        conn.execute(TextClause("CREATE TABLE foo (id INTEGER)"))
+        conn.execute(TextClause("alter table foo add column name varchar(20)"))

--- a/tests/test_sqlalchemy.py
+++ b/tests/test_sqlalchemy.py
@@ -44,9 +44,3 @@ def test_reflect(snowflake_engine: Engine):
 
         assert result
         assert result.fetchall() == [(1, "one")]
-
-
-def test_alter_table(snowflake_engine: Engine):
-    with snowflake_engine.connect() as conn:
-        conn.execute(TextClause("CREATE TABLE foo (id INTEGER)"))
-        conn.execute(TextClause("alter table foo add column name varchar(20)"))


### PR DESCRIPTION
fwiw, I'm attempting to use fakesnow to test alembic migrations of snowflake 😬.

You already have a test for `alter table`, but sqlalchemy (versus the raw cursor) always calls `.description` on the results of queries and it was hitting similar issues to issues you've already solved with e.g. `CREATE TABLE` etc.

I deviated from the pattern a little bit because `AlterTable` constructs returned `ALTERTABLE` as the `cmd`. It seemed somewhat unfortunate to compare exactly against that, but also seemed very likely that other ALTER statements would have the same generic output.