### PR TITLE
fix: CREATE DATABASE when using db_path

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -520,7 +520,7 @@ class FakeSnowflakeConnection:
         self.schema = schema and schema.upper()
         self.database_set = False
         self.schema_set = False
-        self.db_path = db_path
+        self.db_path = Path(db_path) if db_path else None
         self.nop_regexes = nop_regexes
         self._paramstyle = snowflake.connector.paramstyle
 
@@ -535,7 +535,7 @@ class FakeSnowflakeConnection:
                 where catalog_name = '{self.database}'"""
             ).fetchone()
         ):
-            db_file = f"{Path(db_path)/self.database}.db" if db_path else ":memory:"
+            db_file = f"{self.db_path/self.database}.db" if self.db_path else ":memory:"
             duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {self.database}")
             duck_conn.execute(info_schema.creation_sql(self.database))
             duck_conn.execute(macros.creation_sql(self.database))

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -114,7 +114,7 @@ def create_database(expression: exp.Expression, db_path: Path | None = None) -> 
         ident = expression.find(exp.Identifier)
         assert ident, f"No identifier in {expression.sql}"
         db_name = ident.this
-        db_file = f"{db_path}/{db_name}.db" if db_path else ":memory:"
+        db_file = f"{db_path/db_name}.db" if db_path else ":memory:"
 
         return exp.Command(
             this="ATTACH",

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -114,7 +114,7 @@ def create_database(expression: exp.Expression, db_path: Path | None = None) -> 
         ident = expression.find(exp.Identifier)
         assert ident, f"No identifier in {expression.sql}"
         db_name = ident.this
-        db_file = f"{db_path/db_name}.db" if db_path else ":memory:"
+        db_file = f"{db_path}/{db_name}.db" if db_path else ":memory:"
 
         return exp.Command(
             this="ATTACH",

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -201,6 +201,11 @@ def test_connect_reuse_db():
         ):
             assert cur.execute("select * from example").fetchall() == [(420,)]
 
+def test_can_create_duckdb_stored_on_local_filesystem() -> None:
+    with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path:
+        with fakesnow.patch(db_path=db_path):
+            cursor = snowflake.connector.connect().cursor()
+            cursor.execute(f"CREATE DATABASE TEST32cs3s3")
 
 def test_connect_without_database(_fakesnow_no_auto_create: None):
     with snowflake.connector.connect() as conn, conn.cursor() as cur:

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -201,11 +201,12 @@ def test_connect_reuse_db():
         ):
             assert cur.execute("select * from example").fetchall() == [(420,)]
 
-def test_can_create_duckdb_stored_on_local_filesystem() -> None:
-    with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path:
-        with fakesnow.patch(db_path=db_path):
-            cursor = snowflake.connector.connect().cursor()
-            cursor.execute(f"CREATE DATABASE TEST32cs3s3")
+
+def test_connect_db_path_can_create_database() -> None:
+    with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path, fakesnow.patch(db_path=db_path):
+        cursor = snowflake.connector.connect().cursor()
+        cursor.execute("CREATE DATABASE db2")
+
 
 def test_connect_without_database(_fakesnow_no_auto_create: None):
     with snowflake.connector.connect() as conn, conn.cursor() as cur:


### PR DESCRIPTION
When patching in a test specifying a db_path and attempting to create a database:
```
with fakesnow.patch(db_path="databases"):
    cursor = snowflake.connector.connect().cursor()
    cursor.execute(f"CREATE DATABASE TEST32cs3s3")
```
the following error is thrown
```
>           db_file = f"{db_path/db_name}.db" if db_path else ":memory:"
E           TypeError: unsupported operand type(s) for /: 'str' and 'str'
```

This PR fixes the string interpolation.

Note that I expect there is a similar bug in [fakes.py#538](https://github.com/jazzarati/fakesnow/blob/14e6a41bdc133ebc86630467dcaf997c943dfd8a/fakesnow/fakes.py#L538) but I couldn't figure out how to trigger it via a test.

PS: Thanks for making this project