### PR TITLE
fix: Support IF NOT EXISTS in CREATE DATABASE statements

### DIFF
--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -119,9 +119,13 @@ def create_database(expression: exp.Expression, db_path: Path | None = None) -> 
         db_name = ident.this
         db_file = f"{db_path/db_name}.db" if db_path else ":memory:"
 
+        exists_exp = ""
+        if expression.args.get("exists"):
+            exists_exp += "IF NOT EXISTS "
+
         return exp.Command(
             this="ATTACH",
-            expression=exp.Literal(this=f"DATABASE '{db_file}' AS {db_name}", is_string=True),
+            expression=exp.Literal(this=f"{exists_exp}DATABASE '{db_file}' AS {db_name}", is_string=True),
             create_db_name=db_name,
         )
 

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -119,13 +119,11 @@ def create_database(expression: exp.Expression, db_path: Path | None = None) -> 
         db_name = ident.this
         db_file = f"{db_path/db_name}.db" if db_path else ":memory:"
 
-        exists_exp = ""
-        if expression.args.get("exists"):
-            exists_exp += "IF NOT EXISTS "
+        if_not_exists = "IF NOT EXISTS " if expression.args.get("exists") else ""
 
         return exp.Command(
             this="ATTACH",
-            expression=exp.Literal(this=f"{exists_exp}DATABASE '{db_file}' AS {db_name}", is_string=True),
+            expression=exp.Literal(this=f"{if_not_exists}DATABASE '{db_file}' AS {db_name}", is_string=True),
             create_db_name=db_name,
         )
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -144,6 +144,13 @@ def test_create_database() -> None:
         == "ATTACH DATABASE '.databases/foobar.db' AS foobar"
     )
 
+    assert (
+        sqlglot.parse_one("create database if not exists foobar")
+        .transform(create_database, db_path=Path(".databases/"))
+        .sql()
+        == "ATTACH IF NOT EXISTS DATABASE '.databases/foobar.db' AS foobar"
+    )
+
 
 def test_describe_table() -> None:
     assert "SELECT" in sqlglot.parse_one("describe table db1.schema1.table1").transform(describe_table).sql()


### PR DESCRIPTION
If a database already existed and we try to execute "CREATE DATABASE IF NOT EXISTS DB2" then it currently fails with error:
```
snowflake.connector.errors.ProgrammingError: 002043 (02000): Binder Error: Unique file handle conflict: Database "DB2" is already attached with path "...fakesnow-testl1jfag6s/DB2.db"
```

This commit adds support for this functionality by converting the statement to the [duckdb syntax of ATTACH IF NOT EXISTS](https://duckdb.org/docs/sql/statements/attach) when the exists clause is present.

Up to you if you want to keep the test in `test_fakes.py` or only use the one in `test_transforms.py`