### PR TITLE
feat: Implements basic snowflake session variables via SET/UNSET

### DIFF
--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -766,7 +766,9 @@ class Variables:
         if isinstance(expr, exp.Set):
             unset = expr.args.get("unset")
             if not unset:  # SET varname = value;
-                eq = expr.args.get("expressions")[0].this
+                unset_expressions = expr.args.get("expressions")
+                assert unset_expressions, "SET without values in expression(s) is unexpected."
+                eq = unset_expressions[0].this
                 name = eq.this.sql()
                 value = eq.args.get("expression").sql()
                 self._set(name, value)
@@ -774,7 +776,9 @@ class Variables:
                 # Haven't been able to produce this in tests yet due to UNSET being parsed as an Alias expression.
                 raise NotImplementedError("UNSET not supported yet")
         elif self._is_unset_expression(expr):  # Unfortunately UNSET varname; is parsed as an Alias expression :(
-            name = expr.args.get("alias").this
+            alias = expr.args.get("alias")
+            assert alias, "UNSET without value in alias attribute is unexpected."
+            name = alias.this
             self._unset(name)
 
     def _set(self, name: str, value: str) -> None:

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -786,4 +786,10 @@ class Variables:
     def inline_variables(self, sql: str) -> str:
         for name, value in self._variables.items():
             sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
+
+        remaining_variables = re.search(r"\$\w+", sql)
+        if remaining_variables:
+            raise snowflake.connector.errors.ProgrammingError(
+                msg=f"Session variable '{remaining_variables.group().upper()}' does not exist"
+            )
         return sql

--- a/fakesnow/fakes.py
+++ b/fakesnow/fakes.py
@@ -134,12 +134,16 @@ class FakeSnowflakeCursor:
             if os.environ.get("FAKESNOW_DEBUG") == "snowflake":
                 print(f"{command};{params=}" if params else f"{command};", file=sys.stderr)
 
+            command = self._inline_variables(command)
             command, params = self._rewrite_with_params(command, params)
             if self._conn.nop_regexes and any(re.match(p, command, re.IGNORECASE) for p in self._conn.nop_regexes):
                 transformed = transforms.SUCCESS_NOP
             else:
                 expression = parse_one(command, read="snowflake")
                 transformed = self._transform(expression)
+                if Variables.is_variable_modifier(transformed):
+                    self._conn.variables.update_variables(transformed)
+                    transformed = transforms.SUCCESS_NOP  # Nothing further to do if its a SET/UNSET operation.
             return self._execute(transformed, params)
         except snowflake.connector.errors.ProgrammingError as e:
             self._sqlstate = e.sqlstate
@@ -501,6 +505,9 @@ class FakeSnowflakeCursor:
 
         return command, params
 
+    def _inline_variables(self, sql: str) -> str:
+        return self._conn.variables.inline_variables(sql)
+
 
 class FakeSnowflakeConnection:
     def __init__(
@@ -525,6 +532,7 @@ class FakeSnowflakeConnection:
         self.db_path = Path(db_path) if db_path else None
         self.nop_regexes = nop_regexes
         self._paramstyle = snowflake.connector.paramstyle
+        self.variables = Variables()
 
         create_global_database(duck_conn)
 
@@ -734,3 +742,48 @@ def write_pandas(
 
     # return success
     return (True, len(mock_copy_results), count, mock_copy_results)
+
+
+# Implements snowflake variables: https://docs.snowflake.com/en/sql-reference/session-variables#using-variables-in-sql
+class Variables:
+    @classmethod
+    def is_variable_modifier(cls, expr: exp.Expression) -> bool:
+        if isinstance(expr, exp.Set):
+            return True
+        elif cls._is_unset_expression(expr):
+            return expr.this.args.get("this").this == "UNSET"
+        else:
+            return False
+
+    @classmethod
+    def _is_unset_expression(cls, expr: exp.Expression) -> bool:
+        return isinstance(expr, exp.Alias) and expr.this.args.get("this").this == "UNSET"
+
+    def __init__(self) -> None:
+        self._variables = {}
+
+    def update_variables(self, expr: exp.Expression) -> None:
+        if isinstance(expr, exp.Set):
+            unset = expr.args.get("unset")
+            if not unset:  # SET varname = value;
+                eq = expr.args.get("expressions")[0].this
+                name = eq.this.sql()
+                value = eq.args.get("expression").sql()
+                self._set(name, value)
+            else:
+                # Haven't been able to produce this in tests yet due to UNSET being parsed as an Alias expression.
+                raise NotImplementedError("UNSET not supported yet")
+        elif self._is_unset_expression(expr):  # Unfortunately UNSET varname; is parsed as an Alias expression :(
+            name = expr.args.get("alias").this
+            self._unset(name)
+
+    def _set(self, name: str, value: str) -> None:
+        self._variables[name] = value
+
+    def _unset(self, name: str) -> None:
+        self._variables.pop(name)
+
+    def inline_variables(self, sql: str) -> str:
+        for name, value in self._variables.items():
+            sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
+        return sql

--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -8,6 +8,7 @@ import sqlglot
 from sqlglot import exp
 
 from fakesnow.global_database import USERS_TABLE_FQ_NAME
+from fakesnow.variables import Variables
 
 MISSING_DATABASE = "missing_database"
 SUCCESS_NOP = sqlglot.parse_one("SELECT 'Statement executed successfully.'")
@@ -1402,6 +1403,16 @@ def show_keys(
             else:
                 raise NotImplementedError(f"SHOW PRIMARY KEYS with {scope_kind} not yet supported")
         return sqlglot.parse_one(statement)
+    return expression
+
+
+def update_variables(
+    expression: exp.Expression,
+    variables: Variables,
+) -> exp.Expression:
+    if Variables.is_variable_modifier(expression):
+        variables.update_variables(expression)
+        return SUCCESS_NOP  # Nothing further to do if its a SET/UNSET operation.
     return expression
 
 

--- a/fakesnow/variables.py
+++ b/fakesnow/variables.py
@@ -1,0 +1,57 @@
+import re
+
+import snowflake.connector.errors
+from sqlglot import exp
+
+
+# Implements snowflake variables: https://docs.snowflake.com/en/sql-reference/session-variables#using-variables-in-sql
+class Variables:
+    @classmethod
+    def is_variable_modifier(cls, expr: exp.Expression) -> bool:
+        return isinstance(expr, exp.Set) or cls._is_unset_expression(expr)
+
+    @classmethod
+    def _is_unset_expression(cls, expr: exp.Expression) -> bool:
+        if isinstance(expr, exp.Alias):
+            this_expr = expr.this.args.get("this")
+            return isinstance(this_expr, exp.Expression) and this_expr.this == "UNSET"
+        return False
+
+    def __init__(self) -> None:
+        self._variables = {}
+
+    def update_variables(self, expr: exp.Expression) -> None:
+        if isinstance(expr, exp.Set):
+            unset = expr.args.get("unset")
+            if not unset:  # SET varname = value;
+                unset_expressions = expr.args.get("expressions")
+                assert unset_expressions, "SET without values in expression(s) is unexpected."
+                eq = unset_expressions[0].this
+                name = eq.this.sql()
+                value = eq.args.get("expression").sql()
+                self._set(name, value)
+            else:
+                # Haven't been able to produce this in tests yet due to UNSET being parsed as an Alias expression.
+                raise NotImplementedError("UNSET not supported yet")
+        elif self._is_unset_expression(expr):  # Unfortunately UNSET varname; is parsed as an Alias expression :(
+            alias = expr.args.get("alias")
+            assert alias, "UNSET without value in alias attribute is unexpected."
+            name = alias.this
+            self._unset(name)
+
+    def _set(self, name: str, value: str) -> None:
+        self._variables[name] = value
+
+    def _unset(self, name: str) -> None:
+        self._variables.pop(name)
+
+    def inline_variables(self, sql: str) -> str:
+        for name, value in self._variables.items():
+            sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
+
+        remaining_variables = re.search(r"\$\w+", sql)
+        if remaining_variables:
+            raise snowflake.connector.errors.ProgrammingError(
+                msg=f"Session variable '{remaining_variables.group().upper()}' does not exist"
+            )
+        return sql


### PR DESCRIPTION
Implements the very basic usages of sql variables
```
SET var2 = 'blue';
SELECT * from table where color = $var2;                  Produces: SELECT * from table where color = 'blue';
UNSET var2;
```
as described in https://docs.snowflake.com/en/sql-reference/session-variables.

List of features supported and not supported by this PR:

- [x] Variables are scoped to the session (Eg. The connection, not the cursor)
- [x] Simple scalar variables: SET var1 = 1;
- [x] Unset variables: UNSET var1;
- [x] Simple SQL expression variables: SET INCREMENTAL_DATE = DATEADD( 'DAY', -7, CURRENT_DATE());
- [x] Basic use of variables in SQL using $ syntax: SELECT $var1;
- [ ] Multiple variables: SET (var1, var2) = (1, 'hello');
- [ ] Variables set via 'properties' on the connection https://docs.snowflake.com/en/sql-reference/session-variables#setting-variables-on-connection
- [ ] Using variables via the IDENTIFIER function: INSERT INTO IDENTIFIER($my_table_name) (i) VALUES (42);
- [ ] Session variable functions: https://docs.snowflake.com/en/sql-reference/session-variables#session-variable-functions