### PR TITLE
feat: SHOW PRIMARY KEYS for table

### DIFF
--- a/fakesnow/transforms.py
+++ b/fakesnow/transforms.py
@@ -1402,6 +1402,11 @@ def show_keys(
 
                 if schema:
                     statement += f"AND schema_name = '{schema}' "
+            elif scope_kind == "TABLE":
+                if not table:
+                    raise ValueError(f"SHOW PRIMARY KEYS with {scope_kind} scope requires a table")
+
+                statement += f"AND table_name = '{table.name}' "
             else:
                 raise NotImplementedError(f"SHOW PRIMARY KEYS with {scope_kind} not yet supported")
         return sqlglot.parse_one(statement)

--- a/tests/test_info_schema.py
+++ b/tests/test_info_schema.py
@@ -193,3 +193,21 @@ def test_info_schema_views_with_views(conn: snowflake.connector.SnowflakeConnect
                 "comment": None,
             }
         ]
+
+
+def test_info_schema_show_primary_keys_from_table(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    cur.execute(
+        """
+        CREATE TABLE test_table (
+            ID varchar,
+            VERSION varchar,
+            PRIMARY KEY (ID, VERSION)
+        )
+        """
+    )
+
+    cur.execute("SHOW PRIMARY KEYS IN test_table")
+    pk_result = cur.fetchall()
+
+    pk_columns = [result[4] for result in pk_result]
+    assert pk_columns == ["ID", "VERSION"]


### PR DESCRIPTION
Previously there was a `NotImplemented` error when running a query to request the PKs of a table.

I added support for listing the PKs of a table.