### PR TITLE
fix: Only set variables for SetItem expressions

### DIFF
--- a/fakesnow/variables.py
+++ b/fakesnow/variables.py
@@ -5,10 +5,23 @@ from sqlglot import exp
 
 
 # Implements snowflake variables: https://docs.snowflake.com/en/sql-reference/session-variables#using-variables-in-sql
+# [ ] Add support for setting multiple variables in a single statement
 class Variables:
     @classmethod
     def is_variable_modifier(cls, expr: exp.Expression) -> bool:
-        return isinstance(expr, exp.Set) or cls._is_unset_expression(expr)
+        return cls._is_set_expression(expr) or cls._is_unset_expression(expr)
+
+    @classmethod
+    def _is_set_expression(cls, expr: exp.Expression) -> bool:
+        if isinstance(expr, exp.Set):
+            is_set = not expr.args.get("unset")
+            if is_set:  # SET varname = value;
+                set_expressions = expr.args.get("expressions")
+                assert set_expressions, "SET without values in expression(s) is unexpected."
+                # Avoids mistakenly setting variables for statements that use SET in a different context.
+                # (eg. WHEN MATCHED THEN UPDATE SET x=7)
+                return isinstance(set_expressions[0], exp.SetItem)
+        return False
 
     @classmethod
     def _is_unset_expression(cls, expr: exp.Expression) -> bool:
@@ -22,11 +35,11 @@ class Variables:
 
     def update_variables(self, expr: exp.Expression) -> None:
         if isinstance(expr, exp.Set):
-            unset = expr.args.get("unset")
-            if not unset:  # SET varname = value;
-                unset_expressions = expr.args.get("expressions")
-                assert unset_expressions, "SET without values in expression(s) is unexpected."
-                eq = unset_expressions[0].this
+            is_set = not expr.args.get("unset")
+            if is_set:  # SET varname = value;
+                set_expressions = expr.args.get("expressions")
+                assert set_expressions, "SET without values in expression(s) is unexpected."
+                eq = set_expressions[0].this
                 name = eq.this.sql()
                 value = eq.args.get("expression").sql()
                 self._set(name, value)


### PR DESCRIPTION
The existing logic to set a variable was being triggered by some other sql that includes the SET keyword.

I found this case when working on MERGE which has the statement WHEN MATCHED THEN SET ... This triggered the issue. 

Unfortunately we don't currently support MERGE and UPDATE TABLE SET ... statements don't seem to trigger this issue so I couldn't find an existing supported usecase to add a test so there are no new tests.

Once MERGE is built it will fail without this change so its a future test case that will cover us.

In this PR I also inverted the expression and fixed some bad variable naming that was confusing.