### PR TITLE
fix: Ensure type column in information_schema views is not null

### DIFF
--- a/fakesnow/info_schema.py
+++ b/fakesnow/info_schema.py
@@ -62,8 +62,8 @@ case when columns.data_type='BIGINT' then 10
 case when columns.data_type='DOUBLE' then NULL else columns.numeric_scale end as numeric_scale,
 collation_name, is_identity, identity_generation, identity_cycle,
     ddb_columns.comment as comment,
-    null as identity_start,
-    null as identity_increment,
+    null::VARCHAR as identity_start,
+    null::VARCHAR as identity_increment,
 from ${catalog}.information_schema.columns columns
 left join ${catalog}.information_schema._fs_columns_ext ext
   on ext_table_catalog = columns.table_catalog
@@ -86,7 +86,7 @@ select
     catalog_name as database_name,
     'SYSADMIN' as database_owner,
     'NO' as is_transient,
-    null as comment,
+    null::VARCHAR as comment,
     to_timestamp(0)::timestamptz as created,
     to_timestamp(0)::timestamptz as last_altered,
     1 as retention_time,
@@ -116,7 +116,7 @@ select
     to_timestamp(0)::timestamptz as last_altered,
     to_timestamp(0)::timestamptz as last_ddl,
     'SYSADMIN' as last_ddl_by,
-    null as comment
+    null::VARCHAR as comment
 from duckdb_views
 where database_name = '${catalog}'
   and schema_name != 'information_schema'

--- a/tests/test_info_schema.py
+++ b/tests/test_info_schema.py
@@ -217,7 +217,7 @@ def test_type_column_is_not_null(cur: snowflake.connector.cursor.SnowflakeCursor
     for table in [
         "information_schema.databases",
         "information_schema.views",
-        "information_schema._fs_columns_snowflake",
+        "information_schema.columns",
     ]:
         cur.execute(f"DESCRIBE {table}")
         result = cur.fetchall()

--- a/tests/test_info_schema.py
+++ b/tests/test_info_schema.py
@@ -213,7 +213,7 @@ def test_info_schema_show_primary_keys_from_table(cur: snowflake.connector.curso
     assert pk_columns == ["ID", "VERSION"]
 
 
-def test_null_data_type(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+def test_type_column_is_not_null(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
     for table in [
         "information_schema.databases",
         "information_schema.views",

--- a/tests/test_info_schema.py
+++ b/tests/test_info_schema.py
@@ -219,7 +219,7 @@ def test_type_column_is_not_null(cur: snowflake.connector.cursor.SnowflakeCursor
         "information_schema.views",
         "information_schema.columns",
     ]:
-        cur.execute(f"DESCRIBE {table}")
+        cur.execute(f"DESCRIBE VIEW {table}")
         result = cur.fetchall()
         data_types = [dt for (_, dt, *_) in result]
         nulls = [dt for dt in data_types if "NULL" in dt]

--- a/tests/test_info_schema.py
+++ b/tests/test_info_schema.py
@@ -211,3 +211,16 @@ def test_info_schema_show_primary_keys_from_table(cur: snowflake.connector.curso
 
     pk_columns = [result[4] for result in pk_result]
     assert pk_columns == ["ID", "VERSION"]
+
+
+def test_null_data_type(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    for table in [
+        "information_schema.databases",
+        "information_schema.views",
+        "information_schema._fs_columns_snowflake",
+    ]:
+        cur.execute(f"DESCRIBE {table}")
+        result = cur.fetchall()
+        data_types = [dt for (_, dt, *_) in result]
+        nulls = [dt for dt in data_types if "NULL" in dt]
+        assert not nulls


### PR DESCRIPTION
I noticed this when trying to use snowflake-sqlalchemy to test view creation using fakesnow. It's actually sort of also a bug in snowflake-sqlalchemy, that it's hitting an untested code path and failing. but also, this column **should** have a type, and adding one avoids the latent bug in snowflake-sqlalchemy.