### PR TITLE
feat: Convert dollar characters in identifiers

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -197,7 +197,8 @@ class FakeSnowflakeCursor:
 
     def _transform(self, expression: exp.Expression) -> exp.Expression:
         return (
-            expression.transform(transforms.upper_case_unquoted_identifiers)
+            expression.transform(transforms.convert_identifier_dollar_character)
+            .transform(transforms.upper_case_unquoted_identifiers)
             .transform(transforms.update_variables, variables=self._conn.variables)
             .transform(transforms.set_schema, current_database=self._conn.database)
             .transform(transforms.create_database, db_path=self._conn.db_path)

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -19,6 +19,7 @@ from fakesnow.transforms.transforms import (
     array_agg as array_agg,
     array_agg_within_group as array_agg_within_group,
     array_size as array_size,
+    convert_identifier_dollar_character as convert_identifier_dollar_character,
     create_clone as create_clone,
     create_database as create_database,
     create_user as create_user,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -94,6 +94,29 @@ def array_agg_within_group(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
+def convert_identifier_dollar_character(expression: exp.Expression) -> exp.Expression:
+    """Convert the dollar $ characters in identifiers to underscores
+
+    Example:
+        >>> import sqlglot
+        >>> original = "SELECT * FROM ORG$INTERNAL$DATAPRODUCT.SCHEMA.TABLE"
+        >>> sqlglot.parse_one(original).transform(convert_identifier_dollar_character).sql()
+        "SELECT * FROM ORG_INTERNAL_DATAPRODUCT.SCHEMA.TABLE"
+    Args:
+        expression (exp.Expression): the expression that will be transformed.
+
+    Returns:
+        exp.Expression: The transformed expression.
+    """
+    if isinstance(expression, exp.Identifier):
+        name = expression.this
+        if "$" in name:
+            new = expression.copy()
+            new.set("this", name.replace("$", "_"))
+            return new
+    return expression
+
+
 def create_clone(expression: exp.Expression) -> exp.Expression:
     """Transform create table clone to create table as select."""
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -126,6 +126,13 @@ def test_clone(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [(1, "Jenny", True)]
 
 
+def test_convert_identifier_dollar_character(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    cur.execute("CREATE DATABASE ORG$INTERNAL$DATAPRODUCT")
+    cur.execute("CREATE SCHEMA ORG$INTERNAL$DATAPRODUCT.SCHEMA")
+    cur.execute("DESCRIBE DATABASE ORG$INTERNAL$DATAPRODUCT")
+    assert len(cur.fetchall()) == 1
+
+
 def test_create_database_respects_if_not_exists() -> None:
     with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path, fakesnow.patch(db_path=db_path):
         cursor = snowflake.connector.connect().cursor()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -53,7 +53,7 @@ from fakesnow.transforms import (
     upper_case_unquoted_identifiers,
     values_columns,
 )
-from fakesnow.transforms.transforms import _get_to_number_args
+from fakesnow.transforms.transforms import _get_to_number_args, convert_identifier_dollar_character
 
 
 def test_alias_in_join() -> None:
@@ -139,6 +139,15 @@ def test_array_agg_within_group() -> None:
     assert (
         sqlglot.parse_one("SELECT ARRAY_AGG(id) FROM example").transform(array_agg_within_group).sql(dialect="duckdb")
         == "SELECT ARRAY_AGG(id) FROM example"
+    )
+
+
+def test_convert_identifier_dollar_character() -> None:
+    assert (
+        sqlglot.parse_one("SELECT * FROM ORG$INTERNAL$DATAPRODUCT.SCHEMA.TABLE")
+        .transform(convert_identifier_dollar_character)
+        .sql()
+        == "SELECT * FROM ORG_INTERNAL_DATAPRODUCT.SCHEMA.TABLE"
     )
 
 


### PR DESCRIPTION
* Transforms all dollar signs in Snowflake identifiers into underscores. Dollar signs are valid in [Snowflake identifiers](https://docs.snowflake.com/en/sql-reference/identifiers-syntax) but not in DuckDB.