### PR TITLE
fix: support identifiers containing dollar signs

### DIFF
--- a/fakesnow/variables.py
+++ b/fakesnow/variables.py
@@ -62,7 +62,7 @@ class Variables:
         for name, value in self._variables.items():
             sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
 
-        if remaining_variables := re.search(r"(?<!\$)\$\w+", sql):
+        if remaining_variables := re.search(r"(?<![\$_A-Za-z0-9])\$\w+", sql):
             raise snowflake.connector.errors.ProgrammingError(
                 msg=f"Session variable '{remaining_variables.group().upper()}' does not exist"
             )

--- a/fakesnow/variables.py
+++ b/fakesnow/variables.py
@@ -62,7 +62,7 @@ class Variables:
         for name, value in self._variables.items():
             sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
 
-        if remaining_variables := re.search(r"(?<![\$_A-Za-z0-9])\$\w+", sql):
+        if remaining_variables := re.search(r"(?<![\$\w])\$\w+", sql):
             raise snowflake.connector.errors.ProgrammingError(
                 msg=f"Session variable '{remaining_variables.group().upper()}' does not exist"
             )

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -126,15 +126,6 @@ def test_clone(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [(1, "Jenny", True)]
 
 
-def test_convert_identifier_dollar_character(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
-    cur.execute("CREATE DATABASE ORG$INTERNAL;")
-    cur.execute("CREATE SCHEMA ORG$INTERNAL.SCHEMA;")
-    cur.execute("CREATE TABLE ORG$INTERNAL.SCHEMA.TABLE (amount NUMBER);")
-    cur.execute("INSERT INTO ORG$INTERNAL.SCHEMA.TABLE VALUES(1);")
-    cur.execute("SELECT * FROM ORG$INTERNAL.SCHEMA.TABLE;")
-    assert cur.fetchall() == [(1,)]
-
-
 def test_create_database_respects_if_not_exists() -> None:
     with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path, fakesnow.patch(db_path=db_path):
         cursor = snowflake.connector.connect().cursor()
@@ -279,6 +270,11 @@ def test_identifier(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("insert into example values(1)")
     cur.execute("select * from identifier('example')")
     assert cur.fetchall() == [(1,)]
+
+
+def test_identifier_with_dollar_character(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    # shouldn't error
+    cur.execute("CREATE DATABASE ORG$INTERNAL")
 
 
 def test_number_38_0_is_int(cur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -126,6 +126,15 @@ def test_clone(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [(1, "Jenny", True)]
 
 
+def test_convert_identifier_dollar_character(cur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    cur.execute("CREATE DATABASE ORG$INTERNAL;")
+    cur.execute("CREATE SCHEMA ORG$INTERNAL.SCHEMA;")
+    cur.execute("CREATE TABLE ORG$INTERNAL.SCHEMA.TABLE (amount NUMBER);")
+    cur.execute("INSERT INTO ORG$INTERNAL.SCHEMA.TABLE VALUES(1);")
+    cur.execute("SELECT * FROM ORG$INTERNAL.SCHEMA.TABLE;")
+    assert cur.fetchall() == [(1,)]
+
+
 def test_create_database_respects_if_not_exists() -> None:
     with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path, fakesnow.patch(db_path=db_path):
         cursor = snowflake.connector.connect().cursor()


### PR DESCRIPTION
Identifiers containing dollar signs, though valid as per Snowflake documentation, were not supported.

This PR fixes the regexp identifying internal variables:

```
CREATE DATABASE ORG$INTERNAL;

fakesnow/cursor.py:170: in execute
    raise e
fakesnow/cursor.py:148: in execute
    command = self._inline_variables(command)
fakesnow/cursor.py:496: in _inline_variables
    return self._conn.variables.inline_variables(sql)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <fakesnow.variables.Variables object at 0x11e4a2f10>, sql = 'CREATE DATABASE ORG$INTERNAL;'

    def inline_variables(self, sql: str) -> str:
        for name, value in self._variables.items():
            sql = re.sub(rf"\${name}", value, sql, flags=re.IGNORECASE)
    
        if remaining_variables := re.search(r"(?<!\$)\$\w+", sql):
>           raise snowflake.connector.errors.ProgrammingError(
                msg=f"Session variable '{remaining_variables.group().upper()}' does not exist"
            )
E           snowflake.connector.errors.ProgrammingError: Session variable '$INTERNAL' does not exist

fakesnow/variables.py:66: ProgrammingError
```

Resolves #216
