### PR TITLE
feat(server): basic sessionInfo login response

### DIFF
--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -63,6 +63,7 @@ async def login_request(request: Request) -> JSONResponse:
                     {"name": "AUTOCOMMIT", "value": True},
                     {"name": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY", "value": 3600},
                 ],
+                "sessionInfo": {},
             },
             "success": True,
         }

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -234,6 +234,9 @@ def test_server_response_params(server: dict) -> None:
     # expected by the JDBC driver
     assert {"name": "AUTOCOMMIT", "value": True} in response.json()["data"]["parameters"]
 
+    # expected by the .NET connector
+    assert "sessionInfo" in response.json()["data"]
+
 
 def test_server_rowcount(scur: snowflake.connector.cursor.SnowflakeCursor):
     cur = scur


### PR DESCRIPTION
This fixes the .NET connector throwing an error when attempting to connect as it expects a sessionInfo object on the data.

```
> dotnet run snowflake-test.cs
Unhandled exception. Snowflake.Data.Client.SnowflakeDbException (0x80004005): Error: Snowflake Internal Error: Unable to connect. Object reference not set to an instance of an object. SqlState: 08006, VendorCode: 270001, QueryId:
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Snowflake.Data.Core.SFSession.ProcessLoginResponse(LoginResponse authnResponse)
...
```

After this fix fakesnow works from C# and I'm able to successfully run queries.

I thought it was safer to put an empty object to make this connector work rather than populating its fields, but I'm happy to populate the database, schema, warehouse and role if you think they should be in the response.
