### PR TITLE
feat(server): support basic PUT

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,6 +76,14 @@ def scur(
         yield cur
 
 
+@pytest.fixture
+def sdcur(
+    sconn: snowflake.connector.SnowflakeConnection,
+) -> Iterator[snowflake.connector.cursor.DictCursor]:
+    with sconn.cursor(snowflake.connector.cursor.DictCursor) as cur:
+        yield cast(snowflake.connector.cursor.DictCursor, cur)
+
+
 @pytest.fixture()
 def s3_client(moto_session: boto3.Session, cur: snowflake.connector.cursor.SnowflakeCursor) -> S3Client:
     """Configures duckdb to use the moto session and returns an s3 client."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -347,19 +347,3 @@ def test_server_types(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
             2,
         )
     ]
-
-
-def test_server_write_pandas_auto_create(sconn: snowflake.connector.SnowflakeConnection):
-    conn = sconn
-    with conn.cursor() as cur:
-        df = pd.DataFrame.from_records(
-            [
-                {"ID": 1, "FIRST_NAME": "Jenny"},
-                {"ID": 2, "FIRST_NAME": "Jasper"},
-            ]
-        )
-        snowflake.connector.pandas_tools.write_pandas(conn, df, "CUSTOMERS", auto_create_table=True)
-
-        cur.execute("select id, first_name from customers")
-
-        assert cur.fetchall() == [(1, "Jenny"), (2, "Jasper")]


### PR DESCRIPTION
using local storage (ie: LOCAL_FS) because remote storage (eg: S3) uses HTTPS which requires some sort of certificate

only supports default PUT params
