### PR TITLE
refactor: remove use of pandas

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -10,7 +10,6 @@ from types import TracebackType
 from typing import TYPE_CHECKING, Any, cast
 
 import duckdb
-import pandas as pd
 import pyarrow  # needed by fetch_arrow_table()
 import snowflake.connector.converter
 import snowflake.connector.errors
@@ -193,6 +192,8 @@ class FakeSnowflakeCursor:
             raise snowflake.connector.errors.ProgrammingError(msg=msg, errno=9999, sqlstate="99999") from e
 
     def _put_files(self, put_stage_data: stage.UploadCommandDict) -> None:
+        import pandas as pd
+
         results = stage.upload_files(put_stage_data)
         _df = pd.DataFrame.from_records(results)
         self._duck_conn.execute("select * from _df")

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -192,10 +192,8 @@ class FakeSnowflakeCursor:
             raise snowflake.connector.errors.ProgrammingError(msg=msg, errno=9999, sqlstate="99999") from e
 
     def _put_files(self, put_stage_data: stage.UploadCommandDict) -> None:
-        import pandas as pd
-
         results = stage.upload_files(put_stage_data)
-        _df = pd.DataFrame.from_records(results)
+        _df = pyarrow.Table.from_pylist(results)
         self._duck_conn.execute("select * from _df")
         self._arrow_table = self._duck_conn.fetch_arrow_table()
         self._rowcount = self._arrow_table.num_rows

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ notebook = ["duckdb-engine", "ipykernel", "jupysql"]
 # for the standalone server
 [project.optional-dependencies]
 server = ["starlette", "uvicorn"]
-pandas = ["snowflake-connector-python[pandas]"]
 
 [build-system]
 requires = ["setuptools~=80.1"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ notebook = ["duckdb-engine", "ipykernel", "jupysql"]
 # for the standalone server
 [project.optional-dependencies]
 server = ["starlette", "uvicorn"]
+pandas = ["snowflake-connector-python[pandas]"]
 
 [build-system]
 requires = ["setuptools~=80.1"]


### PR DESCRIPTION
Pandas does not appear to be a direct transitive dependency of fakesnow (and you seem to have an `if TYPE_CHECKING` block specifically to lazy-import pandas already).

So this top-level import seems to either be a missing required dependency, or it needs to be inlined/otherwise made lazy.

I'd have made it try/catch at the top level, but that messes up typing typically.

Afaict this is the only direct use of `pd` in the file outside type hints.