### PR TITLE
feat: support scale argument in to_timestamp function

### DIFF
--- a/fakesnow/macros.py
+++ b/fakesnow/macros.py
@@ -44,12 +44,12 @@ FS_TO_TIMESTAMP = Template(
 CREATE OR REPLACE MACRO ${catalog}._fs_to_timestamp(val, scale) AS (
     CASE
         WHEN try_cast(val AS BIGINT) IS NOT NULL
-            THEN 
+            THEN
                 CASE
-                    WHEN scale = 0 THEN to_timestamp(val::BIGINT)
-                    WHEN scale = 3 THEN to_timestamp(val::BIGINT / 1000)
-                    WHEN scale = 6 THEN to_timestamp(val::BIGINT / 1000000)
-                    WHEN scale = 9 THEN to_timestamp(val::BIGINT / 1000000000)
+                    WHEN scale = 0 THEN cast(to_timestamp(val::BIGINT) as TIMESTAMP)
+                    WHEN scale = 3 THEN cast(to_timestamp(val::BIGINT / 1000) as TIMESTAMP)
+                    WHEN scale = 6 THEN cast(to_timestamp(val::BIGINT / 1000000) as TIMESTAMP)
+                    WHEN scale = 9 THEN cast(to_timestamp(val::BIGINT / 1000000000) as TIMESTAMP)
                     ELSE NULL
                 END
         ELSE CAST(val AS TIMESTAMP)

--- a/fakesnow/macros.py
+++ b/fakesnow/macros.py
@@ -41,10 +41,17 @@ CREATE OR REPLACE MACRO ${catalog}.array_construct_compact(list) AS (
 
 FS_TO_TIMESTAMP = Template(
     """
-CREATE OR REPLACE MACRO ${catalog}._fs_to_timestamp(val) AS (
+CREATE OR REPLACE MACRO ${catalog}._fs_to_timestamp(val, scale) AS (
     CASE
         WHEN try_cast(val AS BIGINT) IS NOT NULL
-            THEN CAST(to_timestamp(val::BIGINT) AS TIMESTAMP)
+            THEN 
+                CASE
+                    WHEN scale = 0 THEN to_timestamp(val::BIGINT)
+                    WHEN scale = 3 THEN to_timestamp(val::BIGINT / 1000)
+                    WHEN scale = 6 THEN to_timestamp(val::BIGINT / 1000000)
+                    WHEN scale = 9 THEN to_timestamp(val::BIGINT / 1000000000)
+                    ELSE NULL
+                END
         ELSE CAST(val AS TIMESTAMP)
     END
 );

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1114,7 +1114,7 @@ def to_timestamp(expression: exp.Expression) -> exp.Expression:
 
     # to_timestamp used with a Literal
     if isinstance(expression, exp.UnixToTime):
-        return exp.Anonymous(this="_fs_to_timestamp", expressions=[expression.this])
+        return exp.Anonymous(this="_fs_to_timestamp", expressions=[expression.this, expression.args.get("scale", 0)])
     # to_timestamp used with a Column
     elif isinstance(expression, exp.Anonymous) and expression.name.upper() in ["TO_TIMESTAMP", "TO_TIMESTAMP_NTZ"]:
         return exp.Anonymous(this="_fs_to_timestamp", expressions=expression.expressions)

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1111,19 +1111,21 @@ def to_timestamp(expression: exp.Expression) -> exp.Expression:
 
     See https://docs.snowflake.com/en/sql-reference/functions/to_timestamp
     """
-
+    default_scale = exp.Literal(this="0", is_string=False)
     # to_timestamp used with a Literal
     if isinstance(expression, exp.UnixToTime):
-        return exp.Anonymous(this="_fs_to_timestamp", expressions=[expression.this, expression.args.get("scale", 0)])
+        return exp.Anonymous(
+            this="_fs_to_timestamp", expressions=[expression.this, expression.args.get("scale") or default_scale]
+        )
     # to_timestamp used with a Column
     elif isinstance(expression, exp.Anonymous) and expression.name.upper() in ["TO_TIMESTAMP", "TO_TIMESTAMP_NTZ"]:
-        return exp.Anonymous(this="_fs_to_timestamp", expressions=expression.expressions)
+        return exp.Anonymous(this="_fs_to_timestamp", expressions=[*expression.expressions, default_scale])
     # casting to timestamp or timestamp_ntz
     elif isinstance(expression, exp.Cast) and expression.to.this in (
         exp.DataType.Type.TIMESTAMP,
         exp.DataType.Type.TIMESTAMPNTZ,
     ):
-        return exp.Anonymous(this="_fs_to_timestamp", expressions=[expression.this])
+        return exp.Anonymous(this="_fs_to_timestamp", expressions=[expression.this, default_scale])
 
     return expression
 

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -32,6 +32,18 @@ def test_int_seconds_to_timestamp(cur: snowflake.connector.cursor.SnowflakeCurso
     ]
 
 
+def test_milliseconds_to_timestamp_with_scale(cur: snowflake.connector.cursor.SnowflakeCursor):
+    assert cur.execute("select to_timestamp(1748179630122, 3)").fetchall() == [
+        (datetime.datetime(2025, 5, 25, 13, 27, 10, microsecond=122000),)
+    ]
+
+
+def test_microseconds_to_timestamp_with_scale(cur: snowflake.connector.cursor.SnowflakeCursor):
+    assert cur.execute("select to_timestamp_ntz(1748179630212333, 6)").fetchall() == [
+        (datetime.datetime(2025, 5, 25, 13, 27, 10, microsecond=212333),)
+    ]
+
+
 def test_string_seconds_to_timestamp(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.execute("select '1748179630'::timestamp").fetchall() == [(datetime.datetime(2025, 5, 25, 13, 27, 10),)]
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -720,11 +720,13 @@ def test_try_to_decimal() -> None:
 def test_to_timestamp() -> None:
     assert (
         sqlglot.parse_one("SELECT to_timestamp(0)", read="snowflake").transform(to_timestamp).sql(dialect="duckdb")
-        == "SELECT _FS_TO_TIMESTAMP(0)"
+        == "SELECT _FS_TO_TIMESTAMP(0, 0)"
     )
 
     assert (
-        sqlglot.parse_one("SELECT to_timestamp(1752253006000, 3)", read="snowflake").transform(to_timestamp).sql(dialect="duckdb")
+        sqlglot.parse_one("SELECT to_timestamp(1752253006000, 3)", read="snowflake")
+        .transform(to_timestamp)
+        .sql(dialect="duckdb")
         == "SELECT _FS_TO_TIMESTAMP(1752253006000, 3)"
     )
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -723,6 +723,11 @@ def test_to_timestamp() -> None:
         == "SELECT _FS_TO_TIMESTAMP(0)"
     )
 
+    assert (
+        sqlglot.parse_one("SELECT to_timestamp(1752253006000, 3)", read="snowflake").transform(to_timestamp).sql(dialect="duckdb")
+        == "SELECT _FS_TO_TIMESTAMP(1752253006000, 3)"
+    )
+
 
 def test_use() -> None:
     assert (


### PR DESCRIPTION
Snowflake `TO_TIMESTAMP` can accept a `scale` parameter that specifies time units of the number

For seconds, scale = 0
For milliseconds, scale = 3
For microseconds, scale = 6
For nanoseconds, scale = 9

I have adjusted both `_fs_to_timestamp` macro and the `to_timestamp` transformation to take `scale` into account.
Otherwise calls like `TO_TIMESTAMP(1752253006000, 3)` would create incorrect timestamp