### PR TITLE
Support subqueries in CTAS with column list

### DIFF
--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1260,7 +1260,7 @@ def create_table_as(expression: exp.Expression, duck_conn: DuckDBPyConnection) -
     if (
         isinstance(expression, exp.Create)
         and expression.kind == "TABLE"
-        and isinstance(expression.expression, exp.Select)
+        and isinstance(expression.expression, (exp.Select, exp.Subquery))
         and isinstance(expression.this, exp.Schema)
         and len(expression.this.expressions) > 0
     ):
@@ -1268,7 +1268,10 @@ def create_table_as(expression: exp.Expression, duck_conn: DuckDBPyConnection) -
         schema = expression.this
         create_col_defs: list[exp.ColumnDef] = schema.expressions
 
-        select_query = expression.expression
+        if isinstance(expression.expression, exp.Subquery):
+            select_query = expression.expression.unnest()
+        else:
+            select_query = expression.expression
 
         if any(isinstance(expr, exp.Star) for expr in select_query.expressions):
             # convert SELECT * to SELECT <col1>, <col2>, ...

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -145,6 +145,14 @@ def test_create_table_as(dcur: snowflake.connector.cursor.SnowflakeCursor) -> No
     dcur.execute("select * from t1")
     assert dcur.fetchall() == [{"ID": "1"}]
 
+    dcur.execute("create or replace table t1(id varchar) as (select column1 from values (1))")
+    dcur.execute("select * from t1")
+    assert dcur.fetchall() == [{"ID": "1"}]
+
+    dcur.execute("create or replace table t1(id varchar) as (select * from values (1))")
+    dcur.execute("select * from t1")
+    assert dcur.fetchall() == [{"ID": "1"}]
+
 
 def test_dateadd_date_cast(dcur: snowflake.connector.DictCursor):
     q = """


### PR DESCRIPTION
Thanks for the fix of https://github.com/tekumara/fakesnow/issues/235 and the release 0.9.46!

Unfortunately a CTAS query in our project (generated by dbt-snowflake) is not converted and still results in a `Parser Error: syntax error at or near "AS"`. The query looks like:

```py
>>> sqlglot.parse_one("""create or replace table t1(id varchar) as (select * from values (1))""")
Create(
  this=Schema(
    this=Table(
      this=Identifier(this=t1, quoted=False)),
    expressions=[
      ColumnDef(
        this=Identifier(this=id, quoted=False),
        kind=DataType(this=Type.VARCHAR, nested=False))]),
  kind=TABLE,
  replace=True,
  expression=Subquery(
    this=Select(
      expressions=[
        Star()],
      from=From(
        this=Values(
          expressions=[
            Tuple(
              expressions=[
                Literal(this=1, is_string=False)])])))))
```

That is, the select query part is surrounded by parentheses and parsed into a `exp.Subquery`.

This PR adds support of such CTAS with subquery by
- change the condition for the transformation
- `unnest()` the subquery to make a `exp.Select`

My environment:
- fakesnow 0.9.46
- snowflake-connector-python 3.16.0
- sqlglot 26.33.0
- python 3.11.11
- macOS 15.5