### PR TITLE
refactor: Move ALTER TABLE strip CLUSTER BY transform method

### DIFF
--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from fakesnow.transforms.ddl import (
     alter_table_add_multiple_columns as alter_table_add_multiple_columns,
+    alter_table_strip_cluster_by as alter_table_strip_cluster_by,
 )
 from fakesnow.transforms.merge import merge as merge
 from fakesnow.transforms.show import (
@@ -24,7 +25,6 @@ from fakesnow.transforms.stage import (
 from fakesnow.transforms.transforms import (
     SUCCESS_NOP as SUCCESS_NOP,
     alias_in_join as alias_in_join,
-    alter_table_strip_cluster_by as alter_table_strip_cluster_by,
     array_agg as array_agg,
     array_agg_within_group as array_agg_within_group,
     array_construct_etc as array_construct_etc,

--- a/fakesnow/transforms/ddl.py
+++ b/fakesnow/transforms/ddl.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from sqlglot import exp
 
+from fakesnow.transforms.transforms import SUCCESS_NOP
+
 
 def alter_table_add_multiple_columns(expression: exp.Expression) -> list[exp.Expression]:
     """Transform ALTER TABLE ADD COLUMN with multiple columns into separate statements.
@@ -68,3 +70,15 @@ def alter_table_add_multiple_columns(expression: exp.Expression) -> list[exp.Exp
         alter_statements.append(new_alter)
 
     return alter_statements
+
+
+def alter_table_strip_cluster_by(expression: exp.Expression) -> exp.Expression:
+    """Turn alter table cluster by into a no-op"""
+    if (
+        isinstance(expression, exp.Alter)
+        and (actions := expression.args.get("actions"))
+        and len(actions) == 1
+        and (isinstance(actions[0], exp.Cluster))
+    ):
+        return SUCCESS_NOP
+    return expression

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -36,18 +36,6 @@ def alias_in_join(expression: exp.Expression) -> exp.Expression:
     return expression
 
 
-def alter_table_strip_cluster_by(expression: exp.Expression) -> exp.Expression:
-    """Turn alter table cluster by into a no-op"""
-    if (
-        isinstance(expression, exp.Alter)
-        and (actions := expression.args.get("actions"))
-        and len(actions) == 1
-        and (isinstance(actions[0], exp.Cluster))
-    ):
-        return SUCCESS_NOP
-    return expression
-
-
 def array_construct_etc(expression: exp.Expression) -> exp.Expression:
     """Handle ARRAY_CONSTRUCT_* and ARRAY_CAT
 

--- a/tests/test_ddl.py
+++ b/tests/test_ddl.py
@@ -1,6 +1,6 @@
 import sqlglot
 
-from fakesnow.transforms.ddl import alter_table_add_multiple_columns
+from fakesnow.transforms.ddl import alter_table_add_multiple_columns, alter_table_strip_cluster_by
 
 
 def test_alter_table_add_multiple_columns() -> None:
@@ -20,3 +20,10 @@ def test_alter_table_add_multiple_columns() -> None:
     assert len(result_if_not_exists) == 2
     assert result_if_not_exists[0].sql() == "ALTER TABLE IF EXISTS tab1 ADD COLUMN IF NOT EXISTS col1 INT"
     assert result_if_not_exists[1].sql() == "ALTER TABLE IF EXISTS tab1 ADD COLUMN IF NOT EXISTS col2 VARCHAR(50)"
+
+
+def test_alter_table_strip_cluster_by() -> None:
+    assert (
+        sqlglot.parse_one("alter table table1 cluster by (name)").transform(alter_table_strip_cluster_by).sql()
+        == "SELECT 'Statement executed successfully.' AS status"
+    )

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -7,7 +7,6 @@ from sqlglot import exp
 from fakesnow.transforms import (
     SUCCESS_NOP,
     alias_in_join,
-    alter_table_strip_cluster_by,
     array_agg,
     array_agg_within_group,
     array_size,
@@ -83,13 +82,6 @@ def test_alias_in_join() -> None:
         .transform(alias_in_join)
         .sql()
         == "SELECT R.MY_DATE AS R_DATE /* aliased column has table identifier */ FROM REVENUES AS R LEFT JOIN FXRATES AS F ON R.R_DATE = F.MY_DATE"  # noqa: E501
-    )
-
-
-def test_alter_table_strip_cluster_by() -> None:
-    assert (
-        sqlglot.parse_one("alter table table1 cluster by (name)").transform(alter_table_strip_cluster_by).sql()
-        == "SELECT 'Statement executed successfully.' AS status"
     )
 
 


### PR DESCRIPTION
This PR refactors DDL transforms by moving the logic for handling ALTER TABLE strip CLUSTER BY operations into `ddl.py`. No functional changes were made; code was relocated for better organization and maintainability.