### PR TITLE
fix: Handling of sync and async requests

### DIFF
--- a/fakesnow/conn.py
+++ b/fakesnow/conn.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections import OrderedDict
 from collections.abc import Iterable
 from pathlib import Path
 from types import TracebackType
@@ -23,7 +24,7 @@ class FakeSnowflakeConnection:
     def __init__(
         self,
         duck_conn: DuckDBPyConnection,
-        results_cache: dict[str, tuple],
+        results_cache: OrderedDict[str, tuple],
         database: str | None = None,
         schema: str | None = None,
         create_database: bool = True,

--- a/fakesnow/copy_into.py
+++ b/fakesnow/copy_into.py
@@ -204,7 +204,7 @@ def _get_table_columns(
 
 
 def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
-    kwargs = {}
+    kwargs: dict[str, Any] = {}
     force = False
     purge = False
     on_error = "ABORT_STATEMENT"
@@ -381,7 +381,7 @@ def _inserts(
 
     if parquet_info and parquet_info.is_single_variant:
         # Single VARIANT column: convert entire parquet row to JSON
-        inserts = []
+        inserts: list[exp.Expression] = []
         for url in urls:
             parquet_col_names = parquet_info.parquet_columns[url]
 
@@ -543,6 +543,7 @@ class FileTypeHandler(Protocol):
 
     @staticmethod
     def make_eq(name: str, value: list | str | int | bool) -> exp.EQ:
+        expression: exp.Expression
         if isinstance(value, list):
             expression = exp.array(*[exp.Literal(this=str(v), is_string=isinstance(v, str)) for v in value])
         elif isinstance(value, bool):

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -30,7 +30,7 @@ import fakesnow.transforms as transforms
 from fakesnow import logger
 from fakesnow.copy_into import copy_into
 from fakesnow.params import MutableParams
-from fakesnow.rowtype import describe_as_result_metadata
+from fakesnow.rowtype import describe_as_result_metadata, describe_as_rowtype
 from fakesnow.transforms import stage
 
 if TYPE_CHECKING:
@@ -554,12 +554,24 @@ class FakeSnowflakeCursor:
         self._last_params = None if result_sql else params
         self._last_transformed = transformed
 
+        # Compute rowtype for cache (needed by GET endpoint to generate rowsetBase64)
+        # Skip for DESCRIBE queries to avoid infinite recursion
+        try:
+            if cmd not in {"DESCRIBE TABLE", "DESCRIBE VIEW", "DESCRIBE"}:
+                rowtype = describe_as_rowtype(self._describe_last_sql())
+            else:
+                rowtype = []
+        except Exception:
+            # If rowtype computation fails, use empty list as fallback
+            rowtype = []
+
         self._conn.results_cache[self._sfqid] = (
             self._arrow_table,
             self._rowcount,
             self._last_sql,
             self._last_params,
             self._last_transformed,
+            rowtype,  # 6th element - required for result_scan() and get_results_from_sfqid()
         )
 
     def executemany(

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -81,15 +81,15 @@ class FakeSnowflakeCursor:
         self._conn = conn
         self._duck_conn = duck_conn
         self._use_dict_result = use_dict_result
-        self._last_sql = None
-        self._last_params = None
-        self._last_transformed = None
-        self._sqlstate = None
+        self._last_sql: str | None = None
+        self._last_params: MutableParams | None = None
+        self._last_transformed: exp.Expression | None = None
+        self._sqlstate: str | None = None
         self._arraysize = 1
-        self._arrow_table = None
-        self._arrow_table_fetch_index = None
-        self._rowcount = None
-        self._sfqid = None
+        self._arrow_table: pyarrow.Table | None = None
+        self._arrow_table_fetch_index: int | None = None
+        self._rowcount: int | None = None
+        self._sfqid: str | None = None
         self._converter = snowflake.connector.converter.SnowflakeConverter()
         self._prefetch_hook: Callable[[], None] | None = None
 
@@ -213,8 +213,8 @@ class FakeSnowflakeCursor:
                     "Cannot retrieve data on the status of this query. "
                     "No information returned from server for query '{}'"
                 )
-            # Restore the cached result data
-            self._arrow_table, self._rowcount, self._last_sql, self._last_params, self._last_transformed = value
+            # Restore the cached result data (6-tuple: arrow_table, rowcount, last_sql, last_params, last_transformed, rowtype)
+            self._arrow_table, self._rowcount, self._last_sql, self._last_params, self._last_transformed, _ = value
             self._sfqid = sfqid
             self._arrow_table_fetch_index = None
             self._prefetch_hook = None
@@ -357,8 +357,8 @@ class FakeSnowflakeCursor:
                 raise snowflake.connector.errors.ProgrammingError(
                     msg=f"Statement {sfqid} not found", errno=709, sqlstate="02000"
                 )
-            # Restore the cached result data
-            self._arrow_table, self._rowcount, self._last_sql, self._last_params, self._last_transformed = value
+            # Restore the cached result data (6-tuple: arrow_table, rowcount, last_sql, last_params, last_transformed, rowtype)
+            self._arrow_table, self._rowcount, self._last_sql, self._last_params, self._last_transformed, _ = value
             self._sfqid = sfqid
             self._arrow_table_fetch_index = None
             return

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+from collections import OrderedDict
 from typing import Any
 
 import duckdb
@@ -25,7 +26,7 @@ class FakeSnow:
         self.db_path = db_path
         self.nop_regexes = nop_regexes
 
-        self.results_cache: dict[str, tuple] = {}
+        self.results_cache: OrderedDict[str, tuple] = OrderedDict()
         self.duck_conn = duckdb.connect(database=":memory:")
 
         # create a "global" database for storing objects which span databases.

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -59,15 +59,15 @@ class FakeSnow:
             db_name = db_file.stem.upper()
 
             # Skip if already attached
-            if self.duck_conn.execute(
-                f"SELECT * FROM information_schema.schemata WHERE upper(catalog_name) = ?",
-                parameters=(db_name,)
-            ).fetchone():
+            existing = self.duck_conn.execute(
+                f"SELECT * FROM information_schema.schemata WHERE upper(catalog_name) = '{db_name}'"
+            ).fetchone()
+            if existing:
                 logger.info(f"Database {db_name} already attached, skipping")
                 continue
 
             logger.info(f"Attaching existing database: {db_name} from {db_file}")
-            self.duck_conn.execute(f"ATTACH DATABASE ? AS ?", parameters=(str(db_file), db_name))
+            self.duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {db_name}")
             self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
             self.duck_conn.execute(macros.creation_sql(db_name))
 

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -60,9 +60,10 @@ class FakeSnow:
 
             # Skip if already attached
             existing = self.duck_conn.execute(
-                f"SELECT * FROM information_schema.schemata WHERE upper(catalog_name) = '{db_name}'"
+                f"SELECT COUNT(*) FROM information_schema.schemata WHERE upper(catalog_name) = '{db_name}'"
             ).fetchone()
-            if existing:
+            logger.debug(f"Checking existing database {db_name}: [{existing}] attached")
+            if existing and existing[0] > 0:
                 logger.info(f"Database {db_name} already attached, skipping")
                 continue
 

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -67,20 +67,9 @@ class FakeSnow:
                 continue
 
             logger.info(f"Attaching existing database: {db_name} from {db_file}")
-            try:
-                self.duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {db_name}")
-            except duckdb.BinderException:
-                logger.error(f"Failed to attach database {db_name} from {db_file}. Continue.")
-            try:
-                self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
-            except duckdb.BinderException:
-                logger.error(f"Failed to execute info_schema creation SQL for database {db_name}. Continue.")
-            except duckdb.CatalogException:
-                logger.error(f"Failed to execute info_schema creation SQL for database {db_name} due to missing catalog. Continue.")
-            try:
-                self.duck_conn.execute(macros.creation_sql(db_name))
-            except duckdb.BinderException:
-                logger.error(f"Failed to execute macros creation SQL for database {db_name}. Continue.")
+            self.duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {db_name}")
+            self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
+            self.duck_conn.execute(macros.creation_sql(db_name))
 
     def connect(
         self,

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -67,9 +67,20 @@ class FakeSnow:
                 continue
 
             logger.info(f"Attaching existing database: {db_name} from {db_file}")
-            self.duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {db_name}")
-            self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
-            self.duck_conn.execute(macros.creation_sql(db_name))
+            try:
+                self.duck_conn.execute(f"ATTACH DATABASE '{db_file}' AS {db_name}")
+            except duckdb.BinderException:
+                logger.error(f"Failed to attach database {db_name} from {db_file}. Continue.")
+            try:
+                self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
+            except duckdb.BinderException:
+                logger.error(f"Failed to execute info_schema creation SQL for database {db_name}. Continue.")
+            except duckdb.CatalogException:
+                logger.error(f"Failed to execute info_schema creation SQL for database {db_name} due to missing catalog. Continue.")
+            try:
+                self.duck_conn.execute(macros.creation_sql(db_name))
+            except duckdb.BinderException:
+                logger.error(f"Failed to execute macros creation SQL for database {db_name}. Continue.")
 
     def connect(
         self,

--- a/fakesnow/instance.py
+++ b/fakesnow/instance.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
+import logging
 import os
 from collections import OrderedDict
+from pathlib import Path
 from typing import Any
 
 import duckdb
 
 import fakesnow.fakes as fakes
+import fakesnow.macros as macros
 from fakesnow import info_schema
 from fakesnow.transforms import show
+
+logger = logging.getLogger("fakesnow.instance")
 
 GLOBAL_DATABASE_NAME = "_fs_global"
 
@@ -37,6 +42,34 @@ class FakeSnow:
 
         # use UTC instead of local time zone for consistent testing
         self.duck_conn.execute("SET GLOBAL TimeZone = 'UTC'")
+
+        # Attach existing database files from db_path for persistence across restarts
+        if self.db_path:
+            self._attach_existing_databases()
+
+    def _attach_existing_databases(self) -> None:
+        """Scan db_path for existing .db files and attach them."""
+        db_path = Path(self.db_path)  # type: ignore[arg-type]
+        if not db_path.is_dir():
+            logger.warning(f"db_path does not exist or is not a directory: {db_path}")
+            return
+
+        for db_file in db_path.glob("*.db"):
+            # Database name is the filename without .db extension (uppercase for Snowflake convention)
+            db_name = db_file.stem.upper()
+
+            # Skip if already attached
+            if self.duck_conn.execute(
+                f"SELECT * FROM information_schema.schemata WHERE upper(catalog_name) = ?",
+                parameters=(db_name,)
+            ).fetchone():
+                logger.info(f"Database {db_name} already attached, skipping")
+                continue
+
+            logger.info(f"Attaching existing database: {db_name} from {db_file}")
+            self.duck_conn.execute(f"ATTACH DATABASE ? AS ?", parameters=(str(db_file), db_name))
+            self.duck_conn.execute(info_schema.per_db_creation_sql(db_name))
+            self.duck_conn.execute(macros.creation_sql(db_name))
 
     def connect(
         self,

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gzip
 import json
 import logging
+import os
 import secrets
 from base64 import b64encode
 from dataclasses import dataclass
@@ -36,7 +37,11 @@ class SafeJSONResponse(JSONResponse):
         return json.dumps(content, default=str).encode("utf-8")
 
 
-shared_fs = FakeSnow()
+# Instantiate a shared in-memory FakeSnow instance, or use the database path
+# specified in the environment variable FAKESNOW_DB_PATH. This allows multiple
+# connections to share the same in-memory database, while still allowing for
+# isolated databases if needed.
+shared_fs = FakeSnow(db_path=os.environ.get("FAKESNOW_DB_PATH"))
 sessions: dict[str, FakeSnowflakeConnection] = {}
 
 

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -66,7 +66,7 @@ async def login_request(request: Request) -> JSONResponse:
         # share the in-memory database across connections
         fs = shared_fs
     token = secrets.token_urlsafe(32)
-    logger.info(f"Session login {database=} {schema=} {nop_regexes=}")
+    logger.info(f"[LOGIN] database={database} schema={schema} autocommit={autocommit} nop_regexes={nop_regexes}")
     sessions[token] = fs.connect(database, schema, nop_regexes=nop_regexes, autocommit=autocommit)
     response = {
         "data": {
@@ -88,6 +88,8 @@ async def login_request(request: Request) -> JSONResponse:
 async def query_request(request: Request) -> JSONResponse:
     try:
         conn = to_conn(to_token(request))
+        request_id = request.query_params.get("requestId", "unknown")
+        logger.debug(f"[QUERY_REQUEST] START requestId={request_id} host={request.client.host if request.client else 'unknown'}")
 
         body = await request.body()
         if request.headers.get("Content-Encoding") == "gzip":
@@ -96,11 +98,12 @@ async def query_request(request: Request) -> JSONResponse:
         body_json = json.loads(body)
 
         sql_text = body_json["sqlText"]
+        logger.debug(f"[QUERY_REQUEST] SQL: {sql_text}")
 
         if bindings := body_json.get("bindings"):
             # Convert parameters like {'1': {'type': 'FIXED', 'value': '10'}, ...} to tuple (10, ...)
             params = tuple(from_binding(bindings[str(pos)]) for pos in range(1, len(bindings) + 1))
-            logger.debug(f"Bindings: {params}")
+            logger.debug(f"[QUERY_REQUEST] Bindings: {params}")
         else:
             params = None
 
@@ -108,13 +111,17 @@ async def query_request(request: Request) -> JSONResponse:
 
         try:
             # only a single sql statement is sent at a time by the python snowflake connector
+            logger.debug(f"[QUERY_REQUEST] Executing SQL with params={params}")
             cur = await run_in_threadpool(conn.cursor().execute, sql_text, binding_params=params, server=True)
+            logger.info(f"[QUERY_REQUEST] SQL execution completed, queryId={cur.sfqid}, rowcount={cur._rowcount}")  # noqa: SLF001
+            
             rowtype = describe_as_rowtype(cur._describe_last_sql())  # noqa: SLF001
 
             expr = cur._last_transformed  # noqa: SLF001
             assert expr
             if put_stage_data := expr.args.get("put_stage_data"):
                 # this is a PUT command, so return the stage data
+                logger.info(f"[QUERY_REQUEST] PUT command detected, returning stage data")
                 return SafeJSONResponse(
                     {
                         "data": put_stage_data,
@@ -123,7 +130,7 @@ async def query_request(request: Request) -> JSONResponse:
                 )
 
         except snowflake.connector.errors.ProgrammingError as e:
-            logger.info(f"{sql_text=} ProgrammingError {e}")
+            logger.error(f"[QUERY_REQUEST] ProgrammingError: {sql_text=} errno={e.errno} {e.msg}")
             code = f"{e.errno:06d}"
             response = {
                 "data": {
@@ -134,11 +141,12 @@ async def query_request(request: Request) -> JSONResponse:
                 "message": e.msg,
                 "success": False,
             }
+            logger.error(f"[QUERY_REQUEST] Returning error response: code={code}")
             return SafeJSONResponse(response)
         except Exception as e:
             # we have a bug or use of an unsupported feature
             msg = f"{sql_text=} {params=} Unhandled exception"
-            logger.error(msg, exc_info=e)
+            logger.error(f"[QUERY_REQUEST] {msg}", exc_info=e)
             # my guess at mimicking a 500 error as per https://docs.snowflake.com/en/developer-guide/sql-api/reference
             # and https://github.com/snowflakedb/gosnowflake/blob/8ed4c75ffd707dd712ad843f40189843ace683c4/restful.go#L318
             raise ServerError(status_code=500, code="261000", message=msg) from None
@@ -149,9 +157,11 @@ async def query_request(request: Request) -> JSONResponse:
             # Convert arrow table to array of arrays for Node.js SDK
             # SDK expects [[val1, val2], [val1, val2], ...], not [{col: val}, ...]
             rowset_json = [list(row.values()) for row in cur._arrow_table.to_pylist()]  # noqa: SLF001
+            logger.debug(f"[QUERY_REQUEST] Arrow table: {len(rowset_json)} rows, rowset_b64 length={len(rowset_b64)}")
         else:
             rowset_b64 = ""
             rowset_json = []
+            logger.debug(f"[QUERY_REQUEST] No arrow table, empty result")
 
         # Cache the result data (limit to 50 most recent)
         cache_data = {
@@ -175,15 +185,18 @@ async def query_request(request: Request) -> JSONResponse:
         conn.results_cache[cur.sfqid] = cache_data
         if len(conn.results_cache) > 50:
             conn.results_cache.popitem(last=False)  # Remove oldest item
+        logger.debug(f"[QUERY_REQUEST] Cached result for queryId={cur.sfqid}, cache size={len(conn.results_cache)}")
 
         # Return cache_data with both rowset and rowsetBase64
         response = {
             "data": cache_data,
             "success": True,
         }
+        logger.debug(f"[QUERY_REQUEST] END requestId={request_id} queryId={cur.sfqid} rows={cur._rowcount} status=success code=0")  # noqa: SLF001
         return SafeJSONResponse(response)
 
     except ServerError as e:
+        logger.error(f"[QUERY_REQUEST] ServerError: code={e.code} message={e.message}")
         return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
@@ -217,7 +230,7 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
         rowset_count = len(cached_result.get('rowset', []))
         total_rows = cached_result.get('total', 0)
         
-        logger.info(f"[GET_RESULT] Found cached result: rowtype={rowtype}, rows={rowset_count}/{total_rows}, has_rowset_b64={has_rowset_b64}")
+        logger.debug(f"[GET_RESULT] Found cached result: rowtype={rowtype}, rows={rowset_count}/{total_rows}, has_rowset_b64={has_rowset_b64}")
 
         # For GET /queries/{query_id}/result endpoint:
         # Return cached result with both rowset (JSON) and rowsetBase64 (Arrow)
@@ -226,7 +239,7 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
             "code": "0",  # 0 = Success, results ready immediately
             "success": True,
         }
-        logger.info(f"[GET_RESULT] END query_id={query_id} status=success code=0 rows={rowset_count}")
+        logger.debug(f"[GET_RESULT] END query_id={query_id} status=success code=0 rows={rowset_count}")
         return SafeJSONResponse(response)
         
     except ServerError as e:
@@ -239,16 +252,20 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
 
 def to_token(request: Request) -> str:
     if not (auth := request.headers.get("Authorization")):
+        logger.error(f"[AUTH] Authorization header not found")
         raise ServerError(status_code=401, code="390101", message="Authorization header not found in the request data.")
 
     token = auth[17:-1]
+    logger.debug(f"[AUTH] Token extracted from Authorization header")
     return token
 
 
 def to_conn(token: str) -> FakeSnowflakeConnection:
     if not (conn := sessions.get(token)):
+        logger.error(f"[AUTH] Session not found for token, available sessions: {len(sessions)}")
         raise ServerError(status_code=401, code="390104", message="User must login again to access the service.")
 
+    logger.debug(f"[AUTH] Session found, database={conn.database} schema={conn.schema}")
     return conn
 
 
@@ -258,13 +275,17 @@ async def session(request: Request) -> JSONResponse:
         _ = to_conn(token)
 
         if bool(request.query_params.get("delete")):
+            logger.info(f"[SESSION] DELETE session")
             del sessions[token]
+        else:
+            logger.debug(f"[SESSION] HEARTBEAT")
 
         return SafeJSONResponse(
             {"data": None, "code": None, "message": None, "success": True},
         )
 
     except ServerError as e:
+        logger.error(f"[SESSION] ServerError: code={e.code} message={e.message}")
         return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
@@ -278,10 +299,13 @@ def monitoring_query(request: Request) -> JSONResponse:
 
         sfqid = request.path_params["sfqid"]
         if not conn.results_cache.get(sfqid):
+            logger.debug(f"[MONITORING] query {sfqid} not found in cache")
             return SafeJSONResponse({"data": {"queries": []}, "success": True})
 
+        logger.debug(f"[MONITORING] query {sfqid} status=SUCCESS")
         return SafeJSONResponse({"data": {"queries": [{"status": "SUCCESS"}]}, "success": True})
     except ServerError as e:
+        logger.error(f"[MONITORING] ServerError: code={e.code} message={e.message}")
         return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -36,7 +36,6 @@ class SafeJSONResponse(JSONResponse):
     def render(self, content: Any) -> bytes:
         return json.dumps(content, default=str).encode("utf-8")
 
-
 shared_fs = FakeSnow()
 sessions: dict[str, FakeSnowflakeConnection] = {}
 
@@ -59,15 +58,23 @@ async def login_request(request: Request) -> JSONResponse:
     nop_regexes = session_params.get("nop_regexes")
     autocommit = session_params.get("AUTOCOMMIT", True)
 
-    # Session parameters take precedence over environment variable for db path, so you can have some sessions share
-    # a database and others use isolated databases
-    if db_path := session_params.get("FAKESNOW_DB_PATH") or os.environ.get("FAKESNOW_DB_PATH"):
-        # isolated creates a new in-memory database, rather than using the shared in-memory database
-        # so this connection won't share any tables with other connections
-        fs = FakeSnow() if db_path == ":isolated:" else FakeSnow(db_path=db_path)
-    else:
-        # share the in-memory database across connections
+    # Session parameters take precedence over environment variable for db path, this allow you to have some sessions
+    # share a database and others use isolated databases
+    db_path = session_params.get("FAKESNOW_DB_PATH") or os.environ.get("FAKESNOW_DB_PATH")
+    if db_path is None:
+        # Use the shared in-memory database. This is shared across all sessions and is cleared when the server restarts.
+        # Useful for sharing data between sessions without needing to manage database files.
         fs = shared_fs
+    elif db_path == ":isolated:":
+        # Explicitly setting FAKESNOW_DB_PATH = ":isolated:", creates a new isolated database in memory for every login.
+        # Connection close is triggered by the context manager when hitting FakeSnowflakeConnection.__exit__()
+        # If used outside of a context manager, users will need to manually close the connection when they're done with
+        # it to release resources.
+        fs = FakeSnow()
+    else:
+        # Use the set value for db_path. This instructs fakesnow to persist databases to the filesystem, making it
+        # persistent across server restarts.
+        fs = FakeSnow(db_path=db_path)
     token = secrets.token_urlsafe(32)
     logger.info(f"[LOGIN] database={database} schema={schema} autocommit={autocommit} nop_regexes={nop_regexes}")
     sessions[token] = fs.connect(database, schema, nop_regexes=nop_regexes, autocommit=autocommit)
@@ -319,6 +326,7 @@ async def session(request: Request) -> JSONResponse:
 
         if bool(request.query_params.get("delete")):
             logger.info(f"[SESSION] DELETE session")
+            sessions[token]._duck_conn.close()  # Close the duckdb connection to release resources
             del sessions[token]
         else:
             logger.debug(f"[SESSION] HEARTBEAT")

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -190,6 +190,7 @@ async def query_request(request: Request) -> JSONResponse:
         # Return cache_data with both rowset and rowsetBase64
         response = {
             "data": cache_data,
+            "code": "0",  # 0 = Success, results ready immediately
             "success": True,
         }
         logger.debug(f"[QUERY_REQUEST] END requestId={request_id} queryId={cur.sfqid} rows={cur._rowcount} status=success code=0")  # noqa: SLF001

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -36,6 +36,7 @@ class SafeJSONResponse(JSONResponse):
     def render(self, content: Any) -> bytes:
         return json.dumps(content, default=str).encode("utf-8")
 
+logger.info(f"Creating shared in-memory database for session")
 shared_fs = FakeSnow()
 sessions: dict[str, FakeSnowflakeConnection] = {}
 
@@ -64,16 +65,19 @@ async def login_request(request: Request) -> JSONResponse:
     if db_path is None:
         # Use the shared in-memory database. This is shared across all sessions and is cleared when the server restarts.
         # Useful for sharing data between sessions without needing to manage database files.
+        logger.info(f"Using shared in-memory database for session")
         fs = shared_fs
     elif db_path == ":isolated:":
         # Explicitly setting FAKESNOW_DB_PATH = ":isolated:", creates a new isolated database in memory for every login.
         # Connection close is triggered by the context manager when hitting FakeSnowflakeConnection.__exit__()
         # If used outside of a context manager, users will need to manually close the connection when they're done with
         # it to release resources.
+        logger.info(f"Using isolated in-memory database for session")
         fs = FakeSnow()
     else:
         # Use the set value for db_path. This instructs fakesnow to persist databases to the filesystem, making it
         # persistent across server restarts.
+        logger.info(f"Using persistent database at {db_path} for session")
         fs = FakeSnow(db_path=db_path)
     token = secrets.token_urlsafe(32)
     logger.info(f"[LOGIN] database={database} schema={schema} autocommit={autocommit} nop_regexes={nop_regexes}")

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -164,6 +164,11 @@ async def query_request(request: Request) -> JSONResponse:
             "finalDatabaseName": conn.database,
             "finalSchemaName": conn.schema,
         }
+        
+        # Store in cache, maintaining max 50 entries (LRU)
+        conn.results_cache[cur.sfqid] = cache_data
+        if len(conn.results_cache) > 50:
+            conn.results_cache.popitem(last=False)  # Remove oldest item
 
         # Return cache_data with both rowset and rowsetBase64
         response = {
@@ -173,6 +178,53 @@ async def query_request(request: Request) -> JSONResponse:
         return JSONResponse(response)
 
     except ServerError as e:
+        return JSONResponse(
+            {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
+            status_code=e.status_code,
+        )
+
+async def get_cached_query_result(request: Request) -> JSONResponse:
+    try:
+        token = to_token(request)
+        conn = to_conn(token)
+        
+        # Extract query_id from path: /queries/{query_id}/result
+        query_id = request.path_params.get("query_id")
+        request_guid = request.query_params.get("request_guid", "unknown")
+        disable_offline_chunks = request.query_params.get("disableOfflineChunks", "unknown")
+        
+        logger.info(f"[GET_RESULT] START query_id={query_id} request_guid={request_guid} disableOfflineChunks={disable_offline_chunks} client={request.client.host if request.client else 'unknown'}")
+        
+        if not query_id:
+            logger.error(f"[GET_RESULT] Missing query_id in request path")
+            raise ServerError(status_code=400, code="002003", message="Missing query_id in request path")
+        
+        # Retrieve from cache
+        cached_result = conn.results_cache.get(query_id)
+
+        if not cached_result:
+            logger.error(f"[GET_RESULT] Query results not found for query_id={query_id}, cache keys: {list(conn.results_cache.keys())}")
+            raise ServerError(status_code=404, code="000604", message=f"Query results not found for query_id: {query_id}")
+
+        rowtype = cached_result.get('rowtype')
+        has_rowset_b64 = bool(cached_result.get('rowsetBase64'))
+        rowset_count = len(cached_result.get('rowset', []))
+        total_rows = cached_result.get('total', 0)
+        
+        logger.info(f"[GET_RESULT] Found cached result: rowtype={rowtype}, rows={rowset_count}/{total_rows}, has_rowset_b64={has_rowset_b64}")
+
+        # For GET /queries/{query_id}/result endpoint:
+        # Return cached result with both rowset (JSON) and rowsetBase64 (Arrow)
+        response = {
+            "data": cached_result,
+            "code": "0",  # 0 = Success, results ready immediately
+            "success": True,
+        }
+        logger.info(f"[GET_RESULT] END query_id={query_id} status=success code=0 rows={rowset_count}")
+        return JSONResponse(response)
+        
+    except ServerError as e:
+        logger.error(f"[GET_RESULT] ServerError: code={e.code} message={e.message}")
         return JSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
@@ -234,6 +286,11 @@ routes = [
         "/queries/v1/query-request",
         query_request,
         methods=["POST"],
+    ),
+    Route(
+        "/queries/{query_id}/result",
+        get_cached_query_result,
+        methods=["GET"],
     ),
     Route("/queries/v1/abort-request", lambda _: JSONResponse({"success": True}), methods=["POST"]),
     Route("/monitoring/queries/{sfqid}", monitoring_query, methods=["GET"]),

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -28,6 +28,14 @@ logger = logging.getLogger("fakesnow.server")
 logger.handlers = logging.getLogger("uvicorn").handlers
 logger.setLevel(logging.INFO)
 
+
+class SafeJSONResponse(JSONResponse):
+    """JSONResponse that handles non-serializable types like datetime."""
+
+    def render(self, content: Any) -> bytes:
+        return json.dumps(content, default=str).encode("utf-8")
+
+
 shared_fs = FakeSnow()
 sessions: dict[str, FakeSnowflakeConnection] = {}
 
@@ -60,22 +68,21 @@ async def login_request(request: Request) -> JSONResponse:
     token = secrets.token_urlsafe(32)
     logger.info(f"Session login {database=} {schema=} {nop_regexes=}")
     sessions[token] = fs.connect(database, schema, nop_regexes=nop_regexes, autocommit=autocommit)
-    return JSONResponse(
-        {
-            "data": {
-                "token": token,
-                "parameters": [
-                    {"name": "AUTOCOMMIT", "value": autocommit},
-                    {"name": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY", "value": 3600},
-                ],
-                "sessionInfo": {
-                    "databaseName": database,
-                    "schemaName": schema,
-                },
+    response = {
+        "data": {
+            "token": token,
+            "parameters": [
+                {"name": "AUTOCOMMIT", "value": autocommit},
+                {"name": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY", "value": 3600},
+            ],
+            "sessionInfo": {
+                "databaseName": database,
+                "schemaName": schema,
             },
-            "success": True,
-        }
-    )
+        },
+        "success": True,
+    }
+    return SafeJSONResponse(response)
 
 
 async def query_request(request: Request) -> JSONResponse:
@@ -108,7 +115,7 @@ async def query_request(request: Request) -> JSONResponse:
             assert expr
             if put_stage_data := expr.args.get("put_stage_data"):
                 # this is a PUT command, so return the stage data
-                return JSONResponse(
+                return SafeJSONResponse(
                     {
                         "data": put_stage_data,
                         "success": True,
@@ -118,17 +125,16 @@ async def query_request(request: Request) -> JSONResponse:
         except snowflake.connector.errors.ProgrammingError as e:
             logger.info(f"{sql_text=} ProgrammingError {e}")
             code = f"{e.errno:06d}"
-            return JSONResponse(
-                {
-                    "data": {
-                        "errorCode": code,
-                        "sqlState": e.sqlstate,
-                    },
-                    "code": code,
-                    "message": e.msg,
-                    "success": False,
-                }
-            )
+            response = {
+                "data": {
+                    "errorCode": code,
+                    "sqlState": e.sqlstate,
+                },
+                "code": code,
+                "message": e.msg,
+                "success": False,
+            }
+            return SafeJSONResponse(response)
         except Exception as e:
             # we have a bug or use of an unsupported feature
             msg = f"{sql_text=} {params=} Unhandled exception"
@@ -175,10 +181,10 @@ async def query_request(request: Request) -> JSONResponse:
             "data": cache_data,
             "success": True,
         }
-        return JSONResponse(response)
+        return SafeJSONResponse(response)
 
     except ServerError as e:
-        return JSONResponse(
+        return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
         )
@@ -221,11 +227,11 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
             "success": True,
         }
         logger.info(f"[GET_RESULT] END query_id={query_id} status=success code=0 rows={rowset_count}")
-        return JSONResponse(response)
+        return SafeJSONResponse(response)
         
     except ServerError as e:
         logger.error(f"[GET_RESULT] ServerError: code={e.code} message={e.message}")
-        return JSONResponse(
+        return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
         )
@@ -235,7 +241,8 @@ def to_token(request: Request) -> str:
     if not (auth := request.headers.get("Authorization")):
         raise ServerError(status_code=401, code="390101", message="Authorization header not found in the request data.")
 
-    return auth[17:-1]
+    token = auth[17:-1]
+    return token
 
 
 def to_conn(token: str) -> FakeSnowflakeConnection:
@@ -253,26 +260,32 @@ async def session(request: Request) -> JSONResponse:
         if bool(request.query_params.get("delete")):
             del sessions[token]
 
-        return JSONResponse(
+        return SafeJSONResponse(
             {"data": None, "code": None, "message": None, "success": True},
         )
 
     except ServerError as e:
-        return JSONResponse(
+        return SafeJSONResponse(
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
         )
 
 
 def monitoring_query(request: Request) -> JSONResponse:
-    token = to_token(request)
-    conn = to_conn(token)
+    try:
+        token = to_token(request)
+        conn = to_conn(token)
 
-    sfqid = request.path_params["sfqid"]
-    if not conn.results_cache.get(sfqid):
-        return JSONResponse({"data": {"queries": []}, "success": True})
+        sfqid = request.path_params["sfqid"]
+        if not conn.results_cache.get(sfqid):
+            return SafeJSONResponse({"data": {"queries": []}, "success": True})
 
-    return JSONResponse({"data": {"queries": [{"status": "SUCCESS"}]}, "success": True})
+        return SafeJSONResponse({"data": {"queries": [{"status": "SUCCESS"}]}, "success": True})
+    except ServerError as e:
+        return SafeJSONResponse(
+            {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
+            status_code=e.status_code,
+        )
 
 
 routes = [
@@ -292,7 +305,7 @@ routes = [
         get_cached_query_result,
         methods=["GET"],
     ),
-    Route("/queries/v1/abort-request", lambda _: JSONResponse({"success": True}), methods=["POST"]),
+    Route("/queries/v1/abort-request", lambda _: SafeJSONResponse({"success": True}), methods=["POST"]),
     Route("/monitoring/queries/{sfqid}", monitoring_query, methods=["GET"]),
 ]
 

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -140,8 +140,12 @@ async def query_request(request: Request) -> JSONResponse:
         if cur._arrow_table:  # noqa: SLF001
             batch_bytes = to_ipc(to_sf(cur._arrow_table, rowtype))  # noqa: SLF001
             rowset_b64 = b64encode(batch_bytes).decode("utf-8")
+            # Convert arrow table to array of arrays for Node.js SDK
+            # SDK expects [[val1, val2], [val1, val2], ...], not [{col: val}, ...]
+            rowset_json = [list(row.values()) for row in cur._arrow_table.to_pylist()]  # noqa: SLF001
         else:
             rowset_b64 = ""
+            rowset_json = []
 
         # Cache the result data (limit to 50 most recent)
         cache_data = {
@@ -149,10 +153,14 @@ async def query_request(request: Request) -> JSONResponse:
                 {"name": "TIMEZONE", "value": "Etc/UTC"},
             ],
             "rowtype": rowtype,
-            "rowsetBase64": rowset_b64,
+            "rowsetBase64": rowset_b64,  # For Python SDK
+            "rowset": rowset_json,  # For Node.js SDK
             "total": cur._rowcount,  # noqa: SLF001
+            "returned": cur._rowcount,  # noqa: SLF001  # Node.js SDK needs this
             "queryId": cur.sfqid,
             "queryResultFormat": "arrow",
+            "version": 1,  # Node.js SDK requires version field
+            "chunks": [],  # Node.js SDK expects chunks field (empty list, not None)
             "finalDatabaseName": conn.database,
             "finalSchemaName": conn.schema,
         }

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -24,10 +24,15 @@ from fakesnow.fakes import FakeSnowflakeConnection
 from fakesnow.instance import FakeSnow
 from fakesnow.rowtype import describe_as_rowtype
 
+# Configure parent logger so all fakesnow.* loggers inherit handlers and level
+fakesnow_logger = logging.getLogger("fakesnow")
+fakesnow_logger.handlers = logging.getLogger("uvicorn").handlers
+if os.environ.get("LOG_LEVEL", "").lower() == "debug":
+    fakesnow_logger.setLevel(logging.DEBUG)
+else:
+    fakesnow_logger.setLevel(logging.INFO)
+
 logger = logging.getLogger("fakesnow.server")
-# use same format as uvicorn
-logger.handlers = logging.getLogger("uvicorn").handlers
-logger.setLevel(logging.INFO)
 
 
 class SafeJSONResponse(JSONResponse):

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -37,11 +37,7 @@ class SafeJSONResponse(JSONResponse):
         return json.dumps(content, default=str).encode("utf-8")
 
 
-# Instantiate a shared in-memory FakeSnow instance, or use the database path
-# specified in the environment variable FAKESNOW_DB_PATH. This allows multiple
-# connections to share the same in-memory database, while still allowing for
-# isolated databases if needed.
-shared_fs = FakeSnow(db_path=os.environ.get("FAKESNOW_DB_PATH"))
+shared_fs = FakeSnow()
 sessions: dict[str, FakeSnowflakeConnection] = {}
 
 
@@ -63,7 +59,9 @@ async def login_request(request: Request) -> JSONResponse:
     nop_regexes = session_params.get("nop_regexes")
     autocommit = session_params.get("AUTOCOMMIT", True)
 
-    if db_path := session_params.get("FAKESNOW_DB_PATH"):
+    # Session parameters take precedence over environment variable for db path, so you can have some sessions share
+    # a database and others use isolated databases
+    if db_path := session_params.get("FAKESNOW_DB_PATH") or os.environ.get("FAKESNOW_DB_PATH"):
         # isolated creates a new in-memory database, rather than using the shared in-memory database
         # so this connection won't share any tables with other connections
         fs = FakeSnow() if db_path == ":isolated:" else FakeSnow(db_path=db_path)

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -143,23 +143,26 @@ async def query_request(request: Request) -> JSONResponse:
         else:
             rowset_b64 = ""
 
-        return JSONResponse(
-            {
-                "data": {
-                    "parameters": [
-                        {"name": "TIMEZONE", "value": "Etc/UTC"},
-                    ],
-                    "rowtype": rowtype,
-                    "rowsetBase64": rowset_b64,
-                    "total": cur._rowcount,  # noqa: SLF001
-                    "queryId": cur.sfqid,
-                    "queryResultFormat": "arrow",
-                    "finalDatabaseName": conn.database,
-                    "finalSchemaName": conn.schema,
-                },
-                "success": True,
-            }
-        )
+        # Cache the result data (limit to 50 most recent)
+        cache_data = {
+            "parameters": [
+                {"name": "TIMEZONE", "value": "Etc/UTC"},
+            ],
+            "rowtype": rowtype,
+            "rowsetBase64": rowset_b64,
+            "total": cur._rowcount,  # noqa: SLF001
+            "queryId": cur.sfqid,
+            "queryResultFormat": "arrow",
+            "finalDatabaseName": conn.database,
+            "finalSchemaName": conn.schema,
+        }
+
+        # Return cache_data with both rowset and rowsetBase64
+        response = {
+            "data": cache_data,
+            "success": True,
+        }
+        return JSONResponse(response)
 
     except ServerError as e:
         return JSONResponse(

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -182,7 +182,17 @@ async def query_request(request: Request) -> JSONResponse:
         }
         
         # Store in cache, maintaining max 50 entries (LRU)
-        conn.results_cache[cur.sfqid] = cache_data
+        # Store internal tuple format expected by result_scan() and get_results_from_sfqid()
+        sfqid = cur.sfqid
+        if sfqid is None:
+            raise ServerError(status_code=500, code="261001", message="Missing query id after execution")
+        conn.results_cache[sfqid] = (
+            cur._arrow_table,  # noqa: SLF001
+            cur._rowcount,  # noqa: SLF001
+            cur._last_sql,  # noqa: SLF001
+            cur._last_params,  # noqa: SLF001
+            cur._last_transformed,  # noqa: SLF001
+        )
         if len(conn.results_cache) > 50:
             conn.results_cache.popitem(last=False)  # Remove oldest item
         logger.debug(f"[QUERY_REQUEST] Cached result for queryId={cur.sfqid}, cache size={len(conn.results_cache)}")
@@ -220,18 +230,47 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
             raise ServerError(status_code=400, code="002003", message="Missing query_id in request path")
         
         # Retrieve from cache
-        cached_result = conn.results_cache.get(query_id)
+        cached_tuple = conn.results_cache.get(query_id)
 
-        if not cached_result:
+        if not cached_tuple:
             logger.error(f"[GET_RESULT] Query results not found for query_id={query_id}, cache keys: {list(conn.results_cache.keys())}")
             raise ServerError(status_code=404, code="000604", message=f"Query results not found for query_id: {query_id}")
 
-        rowtype = cached_result.get('rowtype')
-        has_rowset_b64 = bool(cached_result.get('rowsetBase64'))
-        rowset_count = len(cached_result.get('rowset', []))
-        total_rows = cached_result.get('total', 0)
-        
-        logger.debug(f"[GET_RESULT] Found cached result: rowtype={rowtype}, rows={rowset_count}/{total_rows}, has_rowset_b64={has_rowset_b64}")
+        # Unpack the cached tuple format (arrow_table, rowcount, last_sql, last_params, last_transformed)
+        arrow_table, rowcount, _, _, last_transformed = cached_tuple
+
+        # Reconstruct response data from cached tuple
+        if arrow_table:
+            rowtype = describe_as_rowtype(last_transformed) if last_transformed else []
+            batch_bytes = to_ipc(to_sf(arrow_table, rowtype))
+            rowset_b64 = b64encode(batch_bytes).decode("utf-8")
+            rowset_json = [list(row.values()) for row in arrow_table.to_pylist()]
+        else:
+            rowtype = []
+            rowset_b64 = ""
+            rowset_json = []
+
+        has_rowset_b64 = bool(rowset_b64)
+        rowset_count = len(rowset_json)
+
+        logger.debug(f"[GET_RESULT] Found cached result: rowtype={rowtype}, rows={rowset_count}/{rowcount}, has_rowset_b64={has_rowset_b64}")
+
+        cached_result = {
+            "parameters": [
+                {"name": "TIMEZONE", "value": "Etc/UTC"},
+            ],
+            "rowtype": rowtype,
+            "rowsetBase64": rowset_b64,
+            "rowset": rowset_json,
+            "total": rowcount,
+            "returned": rowcount,
+            "queryId": query_id,
+            "queryResultFormat": "arrow",
+            "version": 1,
+            "chunks": [],
+            "finalDatabaseName": conn.database,
+            "finalSchemaName": conn.schema,
+        }
 
         # For GET /queries/{query_id}/result endpoint:
         # Return cached result with both rowset (JSON) and rowsetBase64 (Arrow)

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -192,6 +192,7 @@ async def query_request(request: Request) -> JSONResponse:
             cur._last_sql,  # noqa: SLF001
             cur._last_params,  # noqa: SLF001
             cur._last_transformed,  # noqa: SLF001
+            rowtype,  # rowtype needed for get_cached_query_result()
         )
         if len(conn.results_cache) > 50:
             conn.results_cache.popitem(last=False)  # Remove oldest item
@@ -236,12 +237,11 @@ async def get_cached_query_result(request: Request) -> JSONResponse:
             logger.error(f"[GET_RESULT] Query results not found for query_id={query_id}, cache keys: {list(conn.results_cache.keys())}")
             raise ServerError(status_code=404, code="000604", message=f"Query results not found for query_id: {query_id}")
 
-        # Unpack the cached tuple format (arrow_table, rowcount, last_sql, last_params, last_transformed)
-        arrow_table, rowcount, _, _, last_transformed = cached_tuple
+        # Unpack the cached tuple format (arrow_table, rowcount, last_sql, last_params, last_transformed, rowtype)
+        arrow_table, rowcount, _, _, _, rowtype = cached_tuple
 
         # Reconstruct response data from cached tuple
         if arrow_table:
-            rowtype = describe_as_rowtype(last_transformed) if last_transformed else []
             batch_bytes = to_ipc(to_sf(arrow_table, rowtype))
             rowset_b64 = b64encode(batch_bytes).decode("utf-8")
             rowset_json = [list(row.values()) for row in arrow_table.to_pylist()]

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -173,7 +173,7 @@ def _counts(merge_expr: exp.Merge) -> exp.Expression:
     """
 
     # Initialize dictionaries to store operation types and their corresponding indices
-    operations = {"inserted": [], "updated": [], "deleted": []}
+    operations: dict[str, list[int]] = {"inserted": [], "updated": [], "deleted": []}
 
     # Iterate through the WHEN clauses to categorize operations
     for w_idx, w in enumerate(merge_expr.args["whens"]):

--- a/fakesnow/transforms/show.py
+++ b/fakesnow/transforms/show.py
@@ -191,7 +191,7 @@ def show_keys(
 
     https://docs.snowflake.com/en/sql-reference/sql/show-primary-keys
     """
-    snowflake_kind = kind
+    snowflake_kind: str = kind
     if kind == "FOREIGN":
         snowflake_kind = "IMPORTED"
 
@@ -324,6 +324,7 @@ def show_schemas(expression: exp.Expression, current_database: str | None) -> ex
     See https://docs.snowflake.com/en/sql-reference/sql/show-schemas
     """
     if isinstance(expression, exp.Show) and expression.name.upper() == "SCHEMAS":
+        database: str | None
         if (ident := expression.find(exp.Identifier)) and isinstance(ident.this, str):
             database = ident.this
         else:

--- a/fakesnow/variables.py
+++ b/fakesnow/variables.py
@@ -31,7 +31,7 @@ class Variables:
         return False
 
     def __init__(self) -> None:
-        self._variables = {}
+        self._variables: dict[str, str] = {}
 
     def update_variables(self, expr: exp.Expression) -> None:
         if isinstance(expr, exp.Set):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ dev = [
     "snowflake-connector-python[pandas, secure-local-storage]",
     "snowflake-sqlalchemy~=1.8.2",
     "twine~=6.1",
+    "types-boto3",
+    "types-pytz",
+    "types-requests",
+    "types-sqlalchemy",
 ]
 # for debugging, see https://duckdb.org/docs/guides/python/jupyter.html
 notebook = ["duckdb-engine", "ipykernel", "jupysql"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ from sqlalchemy.engine import Engine, create_engine
 import fakesnow
 import fakesnow.fixtures
 import tests.fixtures.moto
+from fakesnow.cursor import FakeSnowflakeCursor
 
 pytest_plugins = fakesnow.fixtures.__name__, tests.fixtures.moto.__name__
 
@@ -25,21 +26,21 @@ def conn(_fakesnow: None) -> Iterator[snowflake.connector.SnowflakeConnection]:
 
 
 @pytest.fixture
-def cur(conn: snowflake.connector.SnowflakeConnection) -> Iterator[snowflake.connector.cursor.SnowflakeCursor]:
+def cur(conn: snowflake.connector.SnowflakeConnection) -> Iterator[FakeSnowflakeCursor]:
     """
     Yield a snowflake cursor once per session.
     """
     with conn.cursor() as cur:
-        yield cur
+        yield cast(FakeSnowflakeCursor, cur)
 
 
 @pytest.fixture
-def dcur(conn: snowflake.connector.SnowflakeConnection) -> Iterator[snowflake.connector.cursor.DictCursor]:
+def dcur(conn: snowflake.connector.SnowflakeConnection) -> Iterator[FakeSnowflakeCursor]:
     """
-    Yield a snowflake cursor once per session.
+    Yield a snowflake dict cursor once per session.
     """
     with conn.cursor(snowflake.connector.cursor.DictCursor) as cur:
-        yield cast(snowflake.connector.cursor.DictCursor, cur)
+        yield cast(FakeSnowflakeCursor, cur)
 
 
 @pytest.fixture
@@ -81,24 +82,24 @@ def sconn(server: dict) -> Iterator[snowflake.connector.SnowflakeConnection]:
 @pytest.fixture
 def scur(
     sconn: snowflake.connector.SnowflakeConnection,
-) -> Iterator[snowflake.connector.cursor.SnowflakeCursor]:
+) -> Iterator[FakeSnowflakeCursor]:
     with sconn.cursor() as cur:
-        yield cur
+        yield cast(FakeSnowflakeCursor, cur)
 
 
 @pytest.fixture
 def sdcur(
     sconn: snowflake.connector.SnowflakeConnection,
-) -> Iterator[snowflake.connector.cursor.DictCursor]:
+) -> Iterator[FakeSnowflakeCursor]:
     with sconn.cursor(snowflake.connector.cursor.DictCursor) as cur:
-        yield cast(snowflake.connector.cursor.DictCursor, cur)
+        yield cast(FakeSnowflakeCursor, cur)
 
 
 @pytest.fixture()
-def s3_client(moto_session: boto3.Session, cur: snowflake.connector.cursor.SnowflakeCursor) -> S3Client:
+def s3_client(moto_session: boto3.Session, cur: FakeSnowflakeCursor) -> S3Client:
     """Configures duckdb to use the moto session and returns an s3 client."""
 
-    client = moto_session.client("s3")
+    client: S3Client = cast(S3Client, moto_session.client("s3"))
     endpoint_url = client.meta.endpoint_url
 
     creds = moto_session.get_credentials()

--- a/tests/fixtures/moto.py
+++ b/tests/fixtures/moto.py
@@ -1,5 +1,6 @@
 import os
 import time
+from collections.abc import Generator
 
 import boto3
 import pytest
@@ -7,7 +8,7 @@ from moto.server import ThreadedMotoServer
 
 
 @pytest.fixture(scope="session")
-def moto_server():
+def moto_server() -> Generator[str, None, None]:
     server = ThreadedMotoServer(port=0)
     server.start()
     host, port = server.get_host_and_port()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -517,3 +517,170 @@ def test_server_monitoring_endpoint_error(scur: snowflake.connector.cursor.Snowf
     ) as exc:
         cur.fetchall()
     assert exc.value.errno == -1
+
+
+def test_server_result_scan(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    """Test that result_scan() works end-to-end with cached query results."""
+    cur = scur
+
+    # Execute original query
+    cur.execute("select 42 as answer, 'hello world' as message")
+    original_sfqid = cur.sfqid
+    original_result = cur.fetchall()
+
+    # Use result_scan to retrieve cached results
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{original_sfqid}'))")
+    cached_result = cur.fetchall()
+
+    # Verify results match
+    assert cached_result == original_result
+    assert cached_result == [(42, "hello world")]
+
+
+def test_server_get_cached_query_result(server: dict) -> None:
+    """Test the GET /queries/{query_id}/result endpoint directly."""
+    # Connect and execute a query
+    with snowflake.connector.connect(**server, database="db1", schema="schema1") as conn, conn.cursor() as cur:
+        cur.execute("select 123 as number, 'test data' as text")
+        query_id = cur.sfqid
+        _ = cur.fetchall()  # Consume results to ensure they're cached
+
+        # Get the token for authentication
+        assert conn.rest and conn.rest.token
+
+        # Make direct HTTP GET request to the endpoint
+        response = requests.get(
+            f"http://{server['host']}:{server['port']}/queries/{query_id}/result",
+            headers={"Authorization": f'Snowflake Token="{conn.rest.token}"'},
+            timeout=5,
+        )
+
+        assert response.status_code == 200
+        json_response = response.json()
+
+        # Verify response structure
+        assert json_response["success"] is True
+        assert json_response["code"] == "0"  # Success code
+        assert "data" in json_response
+
+        # Verify data fields are present
+        data = json_response["data"]
+        assert "rowtype" in data
+        assert "rowset" in data
+        assert "rowsetBase64" in data
+        assert "total" in data
+        assert "returned" in data
+
+        # Verify data matches original query results
+        assert data["total"] == 1
+        assert data["returned"] == 1
+        assert len(data["rowset"]) == 1
+        assert data["rowset"][0] == [123, "test data"]
+
+
+def test_server_cache_eviction(sconn: snowflake.connector.SnowflakeConnection) -> None:
+    """Test LRU cache behavior when >50 entries."""
+    cur = sconn.cursor()
+
+    # Execute 52 distinct queries to trigger eviction
+    query_ids = []
+    for i in range(52):
+        cur.execute(f"select {i} as value")
+        query_ids.append(cur.sfqid)
+
+    # Verify first query is evicted from cache
+    with pytest.raises(
+        snowflake.connector.errors.ProgrammingError,
+        match="Statement.*not found|Cannot retrieve data on the status of this query",
+    ):
+        cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_ids[0]}'))")
+
+    # Verify 51st and 52nd queries are still in cache
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_ids[50]}'))")
+    assert cur.fetchall() == [(50,)]
+
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_ids[51]}'))")
+    assert cur.fetchall() == [(51,)]
+
+
+def test_server_cache_empty_results(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    """Test caching of queries with no results."""
+    cur = scur
+
+    # Execute query returning 0 rows
+    cur.execute("SELECT * FROM (SELECT 1 AS id) WHERE 1=0")
+    empty_sfqid = cur.sfqid
+    assert cur.fetchall() == []
+    assert cur.rowcount == 0
+
+    # Use result_scan to retrieve cached empty results
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{empty_sfqid}'))")
+    cached_result = cur.fetchall()
+
+    # Verify empty result set is handled correctly
+    assert cached_result == []
+    assert cur.rowcount == 0
+
+
+def test_server_multiple_cached_queries(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    """Test multiple queries cached independently without cross-contamination."""
+    cur = scur
+
+    # Execute 3 different queries with distinct results
+    cur.execute("select 1 as first_query")
+    query_id_1 = cur.sfqid
+    result_1 = cur.fetchall()
+
+    cur.execute("select 'second' as second_query, 999 as number")
+    query_id_2 = cur.sfqid
+    result_2 = cur.fetchall()
+
+    cur.execute("select true as bool_col, 3.14 as pi")
+    query_id_3 = cur.sfqid
+    result_3 = cur.fetchall()
+
+    # Retrieve results in random order using result_scan
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_id_2}'))")
+    assert cur.fetchall() == result_2
+
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_id_1}'))")
+    assert cur.fetchall() == result_1
+
+    cur.execute(f"SELECT * FROM TABLE(RESULT_SCAN('{query_id_3}'))")
+    assert cur.fetchall() == result_3
+
+
+def test_server_get_cached_query_result_errors(server: dict) -> None:
+    """Test error handling in GET endpoint."""
+    # Connect to get a valid token
+    with snowflake.connector.connect(**server, database="db1", schema="schema1") as conn:
+        assert conn.rest and conn.rest.token
+        token = conn.rest.token
+
+        # Test 1: Non-existent query ID - should return 404 or error
+        non_existent_uuid = "00000000-0000-0000-0000-000000000000"
+        response = requests.get(
+            f"http://{server['host']}:{server['port']}/queries/{non_existent_uuid}/result",
+            headers={"Authorization": f'Snowflake Token="{token}"'},
+            timeout=5,
+        )
+
+        # The response should indicate the query was not found
+        # Snowflake returns success=false with an error code
+        assert response.status_code in [200, 404]
+        if response.status_code == 200:
+            json_response = response.json()
+            assert json_response["success"] is False
+
+        # Test 2: Invalid query ID format (not a UUID)
+        response = requests.get(
+            f"http://{server['host']}:{server['port']}/queries/not-a-uuid/result",
+            headers={"Authorization": f'Snowflake Token="{token}"'},
+            timeout=5,
+        )
+
+        # Should handle invalid UUID gracefully
+        assert response.status_code in [200, 400, 404]
+        if response.status_code == 200:
+            json_response = response.json()
+            assert json_response["success"] is False


### PR DESCRIPTION
## Summary

This PR fixes Fakesnow's compatibility with both Node.js and Python Snowflake SDKs by implementing the correct response format and query result polling behavior.

## Changes

### 1. Add status code for successful queries (ff43a93)
- Added `code: "0"` field to POST response to explicitly signal "results ready"
- This field must be set in the response, since the clients are not doing null handling:
  - Without this field, SDKs interpreted responses differently:
    - **Node.js SDK**: Assumed async query → attempted GET request ([decision logic](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v2.3.4/lib/connection/statement.js#L1533-L1574))
    - **Python SDK**: Treated as request failure → retried with new POST requests ([polling logic](https://github.com/snowflakedb/snowflake-connector-python/blob/v4.3.0/src/snowflake/connector/network.py#L800-L815))
- Now both SDKs correctly use inline results without additional requests.
- Returning `code: "0"` does mean that we are essentially never serving async responses. But since I'm still not sure how to make that decision programmatically, I have left it like this for now.

### 2. Add required response fields (a711a9c)
- Added fields expected by both SDKs: `queryId`, `sqlText`, `returned`, `total`, etc.
- Ensures response structure matches SDK expectations for both Node.js (`rowset`) and Python (`rowsetBase64`)

### 3. Add async GET endpoint support (13ad8de)
- Implemented `get_cached_query_result()` function to retrieve cached query results
- Mounted `/queries/{query_id}/result` endpoint for async polling behavior
- Allows SDKs to fetch results via GET when `code: "333333"` (in progress) or `code: "333334"` ([async execution](https://docs.snowflake.com/en/developer-guide/sql-api/reference#label-sql-api-response-codes)) is returned
- Added results cache (`conn.results_cache`) with LRU eviction (max 50 entries) to store query results by `queryId`
- **Note**: This polling endpoint was hit on every single query sent by the async Node.js SDK. After adding the `"code"` field in the `query_request` response, this is *no longer the case*. Since we added a default value (`code: "0"` -- `completed`) to `query_request`, the request will never enter the polling state, and this `GET` endpoint will no longer get hit. But I am leaving it in, since it is already working and, ideally, the `query_request` should be able to return `in-progress` values for `code` as well (perhaps by setting a timeout in on the query execution).

### 4. Add SafeJSONResponse for datetime serialization (88e0bfd)
- Created custom response class to handle non-JSON-serializable types like `datetime`
- Prevents serialization errors when query results contain temporal data
- Uses custom JSON encoder that converts problematic types to strings

### 5. Store results cache in tuple format with rowtype (a16fd35, 63e73fe)
- **Internal cache only**: Results cache (`conn.results_cache`) is never exposed externally - only used for `result_scan()` and `get_results_from_sfqid()`
- Changed cache format from dictionary to 6-tuple: `(arrow_table, rowcount, last_sql, last_params, last_transformed, rowtype)`
- Rowtype is required for GET `/queries/{query_id}/result` endpoint to generate `rowsetBase64` (Arrow IPC format needed by Python SDK)
- Cache uses OrderedDict for LRU eviction (max 50 entries) to prevent unbounded memory growth
- Fixed tuple format consistency: both server.py and cursor.py now store 6-tuple with rowtype

### 6. Add support for persisting database in server mode
Allow clients the option to set `FAKESNOW_DB_PATH` when running in server mode, in order to persist data on disk.

## Technical Details

The changes implement the private SDK API (`/queries/v1/query-request`) used by Node.js and Python Snowflake connectors, not the [public Snowflake SQL API](https://docs.snowflake.com/en/developer-guide/sql-api/guide). Key differences:

- **Success code**: `"0"` (not `"090001"` from public API)
- **Data fields**: `rowset`/`rowsetBase64` (not `data` array from public API)
- **Async codes**: `"333333"` (in progress), `"333334"` (detached) - defined in [Node.js SDK](https://github.com/snowflakedb/snowflake-connector-nodejs/blob/v2.3.4/lib/connection/statement.js#L30-L33) and [Python SDK](https://github.com/snowflakedb/snowflake-connector-python/blob/v4.3.0/src/snowflake/connector/network.py)

See also: [Snowflake SQL API Reference](https://docs.snowflake.com/en/developer-guide/sql-api/reference) for comparison with public API behavior.
