### PR TITLE
feat: implicit VARCHAR-to-numeric cast for aggregate functions

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -316,6 +316,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.create_clone)
             .transform(transforms.alias_in_join)
             .transform(transforms.alter_table_strip_cluster_by)
+            .transform(transforms.numeric_agg_implicit_cast)
             .transform(lambda e: transforms.create_stage(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.list_stage(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.put_stage(e, self._conn.database, self._conn.schema, params))

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -56,6 +56,7 @@ from fakesnow.transforms.transforms import (
     json_extract_cased_as_varchar as json_extract_cased_as_varchar,
     json_extract_cast_as_varchar as json_extract_cast_as_varchar,
     json_extract_precedence as json_extract_precedence,
+    numeric_agg_implicit_cast as numeric_agg_implicit_cast,
     object_agg as object_agg,
     object_construct as object_construct,
     random as random,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1572,7 +1572,16 @@ def sequence_nextval(expression: Expr) -> Expr:
 
 # Numeric-only aggregate functions that fail on VARCHAR in DuckDB.
 # Snowflake implicitly casts VARCHAR to numeric for these.
-_NUMERIC_ONLY_AGGS = (exp.Sum, exp.Avg, exp.Variance, exp.Stddev, exp.StddevSamp, exp.StddevPop, exp.VariancePop, exp.Median)
+_NUMERIC_ONLY_AGGS = (
+    exp.Sum,
+    exp.Avg,
+    exp.Variance,
+    exp.Stddev,
+    exp.StddevSamp,
+    exp.StddevPop,
+    exp.VariancePop,
+    exp.Median,
+)
 
 
 def numeric_agg_implicit_cast(expression: Expr) -> Expr:

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1568,3 +1568,33 @@ def sequence_nextval(expression: Expr) -> Expr:
         )
 
     return expression
+
+
+# Numeric-only aggregate functions that fail on VARCHAR in DuckDB.
+# Snowflake implicitly casts VARCHAR to numeric for these.
+_NUMERIC_ONLY_AGGS = (exp.Sum, exp.Avg, exp.Variance, exp.Stddev, exp.StddevSamp, exp.StddevPop, exp.VariancePop, exp.Median)
+
+
+def numeric_agg_implicit_cast(expression: Expr) -> Expr:
+    """Wrap arguments to numeric aggregate functions with TRY_CAST(... AS DOUBLE).
+
+    Snowflake implicitly casts VARCHAR to numeric when used in aggregate functions
+    like SUM(), AVG(), MEDIAN(), etc. DuckDB is strict and rejects these. This
+    transform adds an explicit TRY_CAST to match Snowflake's behavior.
+
+    Only applies when the argument is not already a Cast/TryCast expression.
+
+    Example:
+        >>> import sqlglot
+        >>> sqlglot.parse_one("SELECT SUM(amount) FROM t").transform(numeric_agg_implicit_cast).sql()
+        "SELECT SUM(TRY_CAST(amount AS DOUBLE)) FROM t"
+    """
+    if isinstance(expression, _NUMERIC_ONLY_AGGS):
+        arg = expression.this
+        # Don't double-cast if already cast
+        if not isinstance(arg, (exp.Cast, exp.TryCast)):
+            expression.set(
+                "this",
+                exp.TryCast(this=arg, to=exp.DataType(this=exp.DataType.Type.DOUBLE)),
+            )
+    return expression

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -669,3 +669,14 @@ def test_variables(conn: snowflake.connector.SnowflakeConnection):
         ),
     ):
         cur.execute("select $var1;")
+
+
+def test_sum_varchar_implicit_cast(cur: snowflake.connector.cursor.SnowflakeCursor):
+    """Snowflake implicitly casts VARCHAR to numeric for aggregate functions like SUM."""
+    cur.execute("CREATE TABLE t_varchar_agg (amount VARCHAR)")
+    cur.execute("INSERT INTO t_varchar_agg VALUES ('100'), ('200'), ('300')")
+    cur.execute("SELECT SUM(amount) FROM t_varchar_agg")
+    assert cur.fetchall() == [(600.0,)]
+
+    cur.execute("SELECT AVG(amount) FROM t_varchar_agg")
+    assert cur.fetchall() == [(200.0,)]

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -1088,3 +1088,43 @@ def test_result_scan() -> None:
         .args.get("result_scan_sfqid")
         == "12345"
     )
+
+
+def test_numeric_agg_implicit_cast() -> None:
+    from fakesnow.transforms.transforms import numeric_agg_implicit_cast
+
+    # SUM(amount) -> SUM(TRY_CAST(amount AS DOUBLE))
+    assert (
+        sqlglot.parse_one("SELECT SUM(amount) FROM t").transform(numeric_agg_implicit_cast).sql()
+        == "SELECT SUM(TRY_CAST(amount AS DOUBLE)) FROM t"
+    )
+
+    # AVG(price) -> AVG(TRY_CAST(price AS DOUBLE))
+    assert (
+        sqlglot.parse_one("SELECT AVG(price) FROM t").transform(numeric_agg_implicit_cast).sql()
+        == "SELECT AVG(TRY_CAST(price AS DOUBLE)) FROM t"
+    )
+
+    # COUNT(name) should NOT be wrapped (not a numeric-only aggregate)
+    assert (
+        sqlglot.parse_one("SELECT COUNT(name) FROM t").transform(numeric_agg_implicit_cast).sql()
+        == "SELECT COUNT(name) FROM t"
+    )
+
+    # MAX(name) should NOT be wrapped
+    assert (
+        sqlglot.parse_one("SELECT MAX(name) FROM t").transform(numeric_agg_implicit_cast).sql()
+        == "SELECT MAX(name) FROM t"
+    )
+
+    # Already-cast args should NOT be double-wrapped
+    assert (
+        sqlglot.parse_one("SELECT SUM(CAST(amount AS DOUBLE)) FROM t").transform(numeric_agg_implicit_cast).sql()
+        == "SELECT SUM(CAST(amount AS DOUBLE)) FROM t"
+    )
+
+    # Multiple aggregates in one query
+    result = sqlglot.parse_one("SELECT SUM(a), COUNT(b), AVG(c) FROM t").transform(numeric_agg_implicit_cast).sql()
+    assert "SUM(TRY_CAST(a AS DOUBLE))" in result
+    assert "COUNT(b)" in result  # unchanged
+    assert "AVG(TRY_CAST(c AS DOUBLE))" in result


### PR DESCRIPTION
## Problem

Snowflake implicitly casts VARCHAR columns to numeric when used in aggregate functions like SUM(), AVG(), MEDIAN(), etc. DuckDB is strict and rejects these:

```
Binder Error: No function matches the given name and argument types 'sum(VARCHAR)'.
```

This is a common pattern when data is loaded via CSV (everything comes in as VARCHAR) and then aggregated without explicit casts.

## Solution

Add a `numeric_agg_implicit_cast` transform that wraps arguments to numeric-only aggregate functions with `TRY_CAST(... AS DOUBLE)`, matching Snowflake's implicit coercion behavior.

- Only applies to numeric-only aggregates: SUM, AVG, MEDIAN, VARIANCE, STDDEV, etc.
- Does NOT affect COUNT, MIN, MAX, ARRAY_AGG, etc. which work on any type
- Skips arguments that are already Cast/TryCast expressions (no double-wrapping)

## Example

```sql
-- Input (Snowflake SQL)
SELECT SUM(amount) FROM t

-- After transform (DuckDB-compatible)
SELECT SUM(TRY_CAST(amount AS DOUBLE)) FROM t
```

## Tests

- Unit tests in `test_transforms.py` covering SUM, AVG, COUNT (unchanged), MAX (unchanged), already-cast args, and mixed queries
- Integration test in `test_fakes.py` verifying end-to-end SUM/AVG on a VARCHAR column