### PR TITLE
fix: Handle join expressions in _missing_qualifiers

### DIFF
--- a/fakesnow/checks.py
+++ b/fakesnow/checks.py
@@ -72,6 +72,9 @@ def _missing_qualifiers(node: exp.Table) -> tuple[bool, bool]:
 
     assert node.parent, f"No parent for table expression {node.sql()}"
 
+    if node.parent.key == "join":
+        return not node.args.get("catalog"), not node.args.get("db")
+
     if (parent_kind := node.parent.args.get("kind")) and isinstance(parent_kind, str):
         if parent_kind.upper() == "DATABASE":
             # "CREATE/DROP DATABASE"

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -78,8 +78,8 @@ def test_check_table_function_does_not_require_current_database() -> None:
         ("SELECT * FROM marts.jaffles.a CROSS JOIN marts.jaffles.b", (False, False)),
         ("SELECT * FROM marts.jaffles.a CROSS JOIN jaffles.b", (True, False)),
         # outer join
-        ("SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id", (True, True)),
-        ("SELECT * FROM a FULL OUTER JOIN b ON a.id = b.id", (True, True)),
+        ("SELECT * FROM a LEFT OUTER JOIN jaffles.b AS B ON a.id = b.id", (True, True)),
+        ("SELECT * FROM jaffles.a as A FULL OUTER JOIN b ON a.id = b.id", (True, True)),
         ("SELECT * FROM marts.jaffles.a LEFT OUTER JOIN marts.jaffles.b ON a.id = b.id", (False, False)),
         ("SELECT * FROM marts.jaffles.a FULL OUTER JOIN marts.jaffles.b ON a.id = b.id", (False, False)),
         ("SELECT * FROM marts.jaffles.a LEFT OUTER JOIN jaffles.b ON a.id = b.id", (True, False)),

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,3 +1,4 @@
+import pytest
 import sqlglot
 
 from fakesnow.checks import is_unqualified_table_expression
@@ -63,3 +64,27 @@ def test_check_table_function_does_not_require_current_database() -> None:
     expression = sqlglot.parse_one("SELECT * FROM table(flatten([1, 2]))", read="snowflake")
 
     assert is_unqualified_table_expression(expression) == (False, False)
+
+
+@pytest.mark.parametrize(
+    "sql,expected",
+    [
+        # inner join
+        ("SELECT * FROM a INNER JOIN b ON a.id = b.id", (True, True)),
+        ("SELECT * FROM marts.jaffles.a INNER JOIN marts.jaffles.b ON a.id = b.id", (False, False)),
+        ("SELECT * FROM marts.jaffles.a INNER JOIN jaffles.b ON a.id = b.id", (True, False)),
+        # cross join
+        ("SELECT * FROM a CROSS JOIN b", (True, True)),
+        ("SELECT * FROM marts.jaffles.a CROSS JOIN marts.jaffles.b", (False, False)),
+        ("SELECT * FROM marts.jaffles.a CROSS JOIN jaffles.b", (True, False)),
+        # outer join
+        ("SELECT * FROM a LEFT OUTER JOIN b ON a.id = b.id", (True, True)),
+        ("SELECT * FROM a FULL OUTER JOIN b ON a.id = b.id", (True, True)),
+        ("SELECT * FROM marts.jaffles.a LEFT OUTER JOIN marts.jaffles.b ON a.id = b.id", (False, False)),
+        ("SELECT * FROM marts.jaffles.a FULL OUTER JOIN marts.jaffles.b ON a.id = b.id", (False, False)),
+        ("SELECT * FROM marts.jaffles.a LEFT OUTER JOIN jaffles.b ON a.id = b.id", (True, False)),
+        ("SELECT * FROM marts.jaffles.a FULL OUTER JOIN jaffles.b ON a.id = b.id", (True, False)),
+    ],
+)
+def test_check_unqualified_joins(sql: str, expected: tuple[bool, bool]) -> None:
+    assert is_unqualified_table_expression(sqlglot.parse_one(sql)) == expected


### PR DESCRIPTION
This PR adds an early return in `_missing_qualifiers` for when a `Table` node's parent is a join expression. Previously, the code fell through to logic that checked the parent's kind argument like `DATABASE`, `SCHEMA`, which joins don't have causing an assertion error, or incorrect result.

Resolves assertion errors like below

```python
            else:
>               raise AssertionError(f"Unexpected parent kind: {parent_kind}")
E               AssertionError: Unexpected parent kind: INNER
```

resolves #336 