### PR TITLE
fix: handle CREATE MACRO in server mode to avoid ProgrammingError

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -528,6 +528,13 @@ class FakeSnowflakeCursor:
             match = re.search(r"SECRET\s+(\w+)\s*\(", transformed.expression, re.IGNORECASE)
             secret_name = match[1].upper() if match else "UNKNOWN"
             result_sql = SQL_CREATED_SECRET.substitute(name=secret_name)
+        elif (
+            cmd == "CREATE"
+            and isinstance(transformed, exp.Command)
+            and isinstance(transformed.expression, str)
+            and re.search(r"\bMACRO\b", transformed.expression, re.IGNORECASE)
+        ):
+            result_sql = SQL_SUCCESS
 
         if table_comment := cast(tuple[exp.Table, str], transformed.args.get("table_comment")):
             # record table comment

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -315,3 +315,9 @@ def test_description_update(dcur: snowflake.connector.cursor.DictCursor):
         ResultMetadata(name='number of multi-joined rows updated', type_code=0, display_size=None, internal_size=None, precision=38, scale=0, is_nullable=True)
     ]
     # fmt: on
+
+
+def test_description_create_macro(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("create or replace macro inc(x) as (x + 1)")
+    assert dcur.fetchall() == [{"status": "Statement executed successfully."}]
+    assert dcur.description == [ResultMetadata(name='status', type_code=2, display_size=None, internal_size=16777216, precision=None, scale=None, is_nullable=True)]  # fmt: skip

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -419,14 +419,6 @@ def test_server_response_params(server: dict) -> None:
     assert {"name": "AUTOCOMMIT", "value": False} in response.json()["data"]["parameters"]
 
 
-def test_server_create_macro(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
-    cur = scur
-    # CREATE MACRO is DuckDB-only DDL; server mode must not raise ProgrammingError
-    cur.execute("CREATE OR REPLACE MACRO inc(x) AS (x + 1)")
-    cur.execute("SELECT inc(41)")
-    assert cur.fetchall() == [(42,)]
-
-
 def test_server_rowcount(scur: snowflake.connector.cursor.SnowflakeCursor):
     cur = scur
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -419,6 +419,14 @@ def test_server_response_params(server: dict) -> None:
     assert {"name": "AUTOCOMMIT", "value": False} in response.json()["data"]["parameters"]
 
 
+def test_server_create_macro(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
+    cur = scur
+    # CREATE MACRO is DuckDB-only DDL; server mode must not raise ProgrammingError
+    cur.execute("CREATE OR REPLACE MACRO inc(x) AS (x + 1)")
+    cur.execute("SELECT inc(41)")
+    assert cur.fetchall() == [(42,)]
+
+
 def test_server_rowcount(scur: snowflake.connector.cursor.SnowflakeCursor):
     cur = scur
 


### PR DESCRIPTION
## Summary

- `CREATE MACRO` is DuckDB-only DDL that sqlglot parses as an opaque `Command`, so it matched none of the `result_sql` branches in `FakeSnowflakeCursor._execute` and left `_last_sql` as the raw DDL string.
- Server mode calls `DESCRIBE <_last_sql>` unconditionally, so `DESCRIBE CREATE OR REPLACE MACRO …` hit DuckDB's parser and raised a `ProgrammingError`, even though the macro was created successfully.
- Fix: add a branch in `_execute` that detects `CREATE … MACRO` (via regex on the opaque `Command.expression`) and assigns `SQL_SUCCESS` as the `result_sql`, consistent with how other DDL is handled.

Fixes #343

## Changes

- [`fakesnow/cursor.py`](fakesnow/cursor.py): new `elif` branch alongside the `SECRET` handler for `CREATE MACRO`
- [`tests/test_server.py`](tests/test_server.py): `test_server_create_macro` regression test

## Test plan

- [x] `uv run pytest tests/test_server.py::test_server_create_macro` passes
- [x] Existing server tests unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)