### PR TITLE
feat: implement HAVERSINE function

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -311,6 +311,7 @@ class FakeSnowflakeCursor:
             .transform(lambda e: transforms.show_keys(e, self._conn.database, kind="FOREIGN"))
             .transform(transforms.show_users)
             .transform(transforms.create_user)
+            .transform(transforms.haversine)
             .transform(transforms.hex_string)
             .transform(transforms.sha256)
             .transform(transforms.create_clone)

--- a/fakesnow/macros.py
+++ b/fakesnow/macros.py
@@ -69,9 +69,22 @@ CREATE OR REPLACE MACRO ${catalog}._fs_to_timestamp(val, scale) AS (
 )
 
 
+FS_HAVERSINE = Template(
+    """
+CREATE OR REPLACE MACRO ${catalog}._fs_haversine(lat1, lon1, lat2, lon2) AS (
+    2 * 6371 * ASIN(SQRT(
+        POWER(SIN(RADIANS(lat2 - lat1) / 2), 2) +
+        COS(RADIANS(lat1)) * COS(RADIANS(lat2)) * POWER(SIN(RADIANS(lon2 - lon1) / 2), 2)
+    ))
+);
+"""
+)
+
+
 def creation_sql(catalog: str) -> str:
     return f"""
         {FS_FLATTEN.substitute(catalog=catalog)};
+        {FS_HAVERSINE.substitute(catalog=catalog)};
         {FS_OBJECT_CONSTRUCT.substitute(catalog=catalog)};
         {FS_TO_TIMESTAMP.substitute(catalog=catalog)};
     """

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -47,6 +47,7 @@ from fakesnow.transforms.transforms import (
     flatten as flatten,
     flatten_value_cast_as_varchar as flatten_value_cast_as_varchar,
     float_to_double as float_to_double,
+    haversine as haversine,
     hex_string as hex_string,
     identifier as identifier,
     indices_to_json_extract as indices_to_json_extract,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -581,6 +581,16 @@ def hex_string(expression: Expr) -> Expr:
     return expression
 
 
+def haversine(expression: Expr) -> Expr:
+    """Transform HAVERSINE to the _fs_haversine macro.
+
+    See https://docs.snowflake.com/en/sql-reference/functions/haversine
+    """
+    if isinstance(expression, exp.Anonymous) and expression.name.upper() == "HAVERSINE":
+        return exp.Anonymous(this="_fs_haversine", expressions=expression.expressions)
+    return expression
+
+
 def identifier(expression: Expr, params: MutableParams | None) -> Expr:
     """Convert identifier function to an identifier or table.
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -310,6 +310,16 @@ def test_floats_are_64bit(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [(1.23, 1.23, 1.23, 1.23, 1.23)]
 
 
+def test_haversine(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # San Francisco (37.7749, -122.4194) to Los Angeles (34.0522, -118.2437) ~ 559 km
+    cur.execute("SELECT ROUND(HAVERSINE(37.7749, -122.4194, 34.0522, -118.2437), 0)")
+    assert cur.fetchone()[0] == 559.0
+
+    # same point -> 0 km
+    cur.execute("SELECT HAVERSINE(0, 0, 0, 0)")
+    assert cur.fetchone()[0] == 0.0
+
+
 def test_hex_decode_binary(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("SELECT HEX_DECODE_BINARY('EDF1439075A83A447FB8B630DDC9C8DE')")
     # NB: Snowflake returns bytesarray instead of bytes


### PR DESCRIPTION
## Summary

- Adds support for Snowflake's [`HAVERSINE(lat1, lon1, lat2, lon2)`](https://docs.snowflake.com/en/sql-reference/functions/haversine) function, which returns the great-circle distance in km between two geographic points
- Implements via a new `_fs_haversine` DuckDB macro using the standard haversine formula with Earth radius 6371 km, consistent with Snowflake's documented behavior
- Adds a sqlglot transform that rewrites `HAVERSINE(...)` calls to `_fs_haversine(...)`, consistent with the existing `_fs_flatten`, `_fs_object_construct`, and `_fs_to_timestamp` pattern

Closes #346

## Test plan

- [x] `test_haversine` added to `tests/test_fakes.py`: verifies SF→LA distance (~559 km) and zero-distance case
- [x] Verified works across non-default databases (per-catalog macro registration + DuckDB search path resolves correctly)
- [x] All 100 existing tests pass
- [x] Ruff and pyright clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)