### PR TITLE
fix: create macros for runtime-created databases

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -26,6 +26,7 @@ from typing_extensions import Self
 import fakesnow.checks as checks
 import fakesnow.expr as expr
 import fakesnow.info_schema as info_schema
+import fakesnow.macros as macros
 import fakesnow.transforms as transforms
 from fakesnow import logger
 from fakesnow.copy_into import copy_into
@@ -446,6 +447,7 @@ class FakeSnowflakeCursor:
         elif create_db_name := transformed.args.get("create_db_name"):
             # we created a new database, so create the info schema extensions
             self._duck_conn.execute(info_schema.per_db_creation_sql(create_db_name))
+            self._duck_conn.execute(macros.creation_sql(create_db_name))
             result_sql = SQL_CREATED_DATABASE.substitute(name=create_db_name)
 
         elif stage_name := transformed.args.get("create_stage_name"):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -90,21 +90,20 @@ def test_connect_db_path_can_create_database() -> None:
 def test_create_database_registers_macros() -> None:
     # _fs_* macros must be registered for databases created via CREATE DATABASE,
     # not only for databases passed at connect time (issue #347)
-    with fakesnow.patch():
-        with snowflake.connector.connect() as conn:
-            cur = conn.cursor()
-            cur.execute("CREATE DATABASE foo")
-            cur.execute("USE DATABASE foo")
-            cur.execute("CREATE SCHEMA foo.bar")
-            cur.execute("USE SCHEMA foo.bar")
-            # TO_TIMESTAMP_NTZ relies on _fs_to_timestamp macro
-            result = cur.execute("SELECT TO_TIMESTAMP_NTZ('1672531200', 0)").fetchone()
-            assert result is not None
-            # LATERAL FLATTEN relies on _fs_flatten macro
-            cur.execute("CREATE TABLE foo.bar.t (arr ARRAY)")
-            cur.execute("INSERT INTO foo.bar.t SELECT ARRAY_CONSTRUCT(1, 2, 3)")
-            rows = cur.execute("SELECT value FROM foo.bar.t, LATERAL FLATTEN(INPUT => arr)").fetchall()
-            assert len(rows) == 3
+    with fakesnow.patch(), snowflake.connector.connect() as conn:
+        cur = conn.cursor()
+        cur.execute("CREATE DATABASE foo")
+        cur.execute("USE DATABASE foo")
+        cur.execute("CREATE SCHEMA foo.bar")
+        cur.execute("USE SCHEMA foo.bar")
+        # TO_TIMESTAMP_NTZ relies on _fs_to_timestamp macro
+        result = cur.execute("SELECT TO_TIMESTAMP_NTZ('1672531200', 0)").fetchone()
+        assert result is not None
+        # LATERAL FLATTEN relies on _fs_flatten macro
+        cur.execute("CREATE TABLE foo.bar.t (arr ARRAY)")
+        cur.execute("INSERT INTO foo.bar.t SELECT ARRAY_CONSTRUCT(1, 2, 3)")
+        rows = cur.execute("SELECT value FROM foo.bar.t, LATERAL FLATTEN(INPUT => arr)").fetchall()
+        assert len(rows) == 3
 
 
 def test_connect_db_path_reuse():

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -87,6 +87,26 @@ def test_connect_db_path_can_create_database() -> None:
         cursor.execute("CREATE DATABASE db2")
 
 
+def test_create_database_registers_macros() -> None:
+    # _fs_* macros must be registered for databases created via CREATE DATABASE,
+    # not only for databases passed at connect time (issue #347)
+    with fakesnow.patch():
+        with snowflake.connector.connect() as conn:
+            cur = conn.cursor()
+            cur.execute("CREATE DATABASE foo")
+            cur.execute("USE DATABASE foo")
+            cur.execute("CREATE SCHEMA foo.bar")
+            cur.execute("USE SCHEMA foo.bar")
+            # TO_TIMESTAMP_NTZ relies on _fs_to_timestamp macro
+            result = cur.execute("SELECT TO_TIMESTAMP_NTZ('1672531200', 0)").fetchone()
+            assert result is not None
+            # LATERAL FLATTEN relies on _fs_flatten macro
+            cur.execute("CREATE TABLE foo.bar.t (arr ARRAY)")
+            cur.execute("INSERT INTO foo.bar.t SELECT ARRAY_CONSTRUCT(1, 2, 3)")
+            rows = cur.execute("SELECT value FROM foo.bar.t, LATERAL FLATTEN(INPUT => arr)").fetchall()
+            assert len(rows) == 3
+
+
 def test_connect_db_path_reuse():
     with tempfile.TemporaryDirectory(prefix="fakesnow-test") as db_path:
         with (


### PR DESCRIPTION
### Why?

Fixes #347.

Fixes a DuckDB catalog error where Snowflake-compatible timestamp conversion can fail after creating a database with `CREATE DATABASE`:

`Scalar Function with name _fs_to_timestamp does not exist`

This change is needed so databases created during a fakesnow session support the same internal compatibility helpers as databases created at connection time.

### How?

Initialize newly created databases with fakesnow’s internal helper macros, so Snowflake SQL rewrites continue to work consistently after switching into a database created during the session.

<sub>Generated with Claude Code</sub>
