### PR TITLE
fix: return statementTypeId so DML and DDL statements work when using the JDBC driver

### DIFF
--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -22,6 +22,7 @@ from fakesnow.expr import normalise_ident
 from fakesnow.fakes import FakeSnowflakeConnection
 from fakesnow.instance import FakeSnow
 from fakesnow.rowtype import describe_as_rowtype
+from fakesnow.statement_type import DML_TYPE_IDS, statement_type_id
 
 logger = logging.getLogger("fakesnow.server")
 # use same format as uvicorn
@@ -102,6 +103,7 @@ async def query_request(request: Request) -> JSONResponse:
             params = None
 
         expr = parse_one(sql_text, read="snowflake")
+        type_id = statement_type_id(expr)
 
         try:
             # only a single sql statement is sent at a time by the python snowflake connector
@@ -141,11 +143,23 @@ async def query_request(request: Request) -> JSONResponse:
             # and https://github.com/snowflakedb/gosnowflake/blob/8ed4c75ffd707dd712ad843f40189843ace683c4/restful.go#L318
             raise ServerError(status_code=500, code="261000", message=msg) from None
 
-        if cur._arrow_table:  # noqa: SLF001
-            batch_bytes = to_ipc(to_sf(cur._arrow_table, rowtype))  # noqa: SLF001
-            rowset_b64 = b64encode(batch_bytes).decode("utf-8")
+        arrow_table = cur._arrow_table  # noqa: SLF001
+
+        if arrow_table and type_id in DML_TYPE_IDS:
+            # DML results are returned as json, because clients read the affected row counts
+            # from rowset, eg: SnowflakeCursor._init_result_and_meta
+            result: dict[str, Any] = {
+                "queryResultFormat": "json",
+                "rowset": [
+                    [None if v is None else str(v) for v in row]
+                    for row in zip(*[c.to_pylist() for c in arrow_table.columns], strict=True)
+                ],
+            }
+        elif arrow_table:
+            batch_bytes = to_ipc(to_sf(arrow_table, rowtype))
+            result = {"queryResultFormat": "arrow", "rowsetBase64": b64encode(batch_bytes).decode("utf-8")}
         else:
-            rowset_b64 = ""
+            result = {"queryResultFormat": "arrow", "rowsetBase64": ""}
 
         return JSONResponse(
             {
@@ -154,12 +168,12 @@ async def query_request(request: Request) -> JSONResponse:
                         {"name": "TIMEZONE", "value": "Etc/UTC"},
                     ],
                     "rowtype": rowtype,
-                    "rowsetBase64": rowset_b64,
                     "total": cur._rowcount,  # noqa: SLF001
                     "queryId": cur.sfqid,
-                    "queryResultFormat": "arrow",
+                    "statementTypeId": type_id,
                     "finalDatabaseName": conn.database,
                     "finalSchemaName": conn.schema,
+                    **result,
                 },
                 "success": True,
             }

--- a/fakesnow/statement_type.py
+++ b/fakesnow/statement_type.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from sqlglot import Expr, exp
+
+# Statement type ids returned by Snowflake as statementTypeId.
+# Clients use them to tell whether a statement produces a result set, eg: the JDBC driver
+# rejects executeUpdate for statements it can't identify, and the python connector uses
+# them to decide how to count affected rows.
+# See net.snowflake.client.core.SFStatementType in snowflake-jdbc, and
+# STATEMENT_TYPE_ID_DML_SET in snowflake-connector-python.
+UNKNOWN = 0x0000
+SELECT = 0x1000
+DML = 0x3000
+INSERT = DML + 0x100
+UPDATE = DML + 0x200
+DELETE = DML + 0x300
+MERGE = DML + 0x400
+MULTI_INSERT = DML + 0x500
+COPY = DML + 0x600
+SCL = 0x4000
+USE = SCL + 0x300
+USE_DATABASE = USE + 0x01
+USE_SCHEMA = USE + 0x02
+USE_WAREHOUSE = USE + 0x03
+SHOW = SCL + 0x400
+DESCRIBE = SCL + 0x500
+TCL = 0x5000
+DDL = 0x6000
+
+# Statements the clients treat as DML, ie: they report affected rows rather than a result set.
+DML_TYPE_IDS = frozenset({DML, INSERT, UPDATE, DELETE, MERGE, MULTI_INSERT})
+
+_EXPRESSION_TYPES: dict[type[Expr], int] = {
+    exp.Select: SELECT,
+    exp.Insert: INSERT,
+    exp.MultitableInserts: MULTI_INSERT,
+    exp.Update: UPDATE,
+    exp.Delete: DELETE,
+    exp.Merge: MERGE,
+    exp.Copy: COPY,
+    exp.Show: SHOW,
+    exp.Describe: DESCRIBE,
+    exp.Create: DDL,
+    exp.Drop: DDL,
+    exp.Alter: DDL,
+    exp.TruncateTable: DDL,
+    exp.Commit: TCL,
+    exp.Rollback: TCL,
+    exp.Transaction: TCL,
+}
+
+_USE_KINDS = {
+    "DATABASE": USE_DATABASE,
+    "SCHEMA": USE_SCHEMA,
+    "WAREHOUSE": USE_WAREHOUSE,
+}
+
+
+def statement_type_id(expression: Expr) -> int:
+    """The Snowflake statement type id for an expression.
+
+    Returns UNKNOWN for statements we don't recognise, which is what Snowflake returns
+    for statements that produce a result set.
+
+    Args:
+        expression (Expr): Expression to check.
+
+    Returns:
+        int: Statement type id, eg: 12544 (INSERT).
+    """
+
+    if isinstance(expression, exp.Use):
+        kind = expression.args.get("kind")
+        return _USE_KINDS.get(kind.name.upper(), USE) if isinstance(kind, exp.Var) else USE
+
+    return _EXPRESSION_TYPES.get(type(expression), UNKNOWN)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -426,6 +426,24 @@ def test_server_rowcount(scur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.rowcount == 2
 
 
+def test_server_rowcount_dml(scur: snowflake.connector.cursor.SnowflakeCursor):
+    cur = scur
+
+    cur.execute("create or replace table example (id int)")
+    cur.execute("insert into example values (1), (2), (3)")
+    assert cur.rowcount == 3
+    cur.execute("update example set id = 9 where id > 1")
+    assert cur.rowcount == 2
+    cur.execute("delete from example where id = 9")
+    assert cur.rowcount == 2
+    cur.execute(
+        "merge into example t using (select 1 as id union all select 7 as id) s on t.id = s.id "
+        "when matched then update set t.id = 5 when not matched then insert (id) values (s.id)"
+    )
+    # 1 row inserted + 1 row updated
+    assert cur.rowcount == 2
+
+
 def test_server_sfid(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
     cur = scur
     assert not cur.sfqid

--- a/tests/test_statement_type.py
+++ b/tests/test_statement_type.py
@@ -1,0 +1,60 @@
+import sqlglot
+from sqlglot import Expr
+
+import fakesnow.statement_type as statement_type
+
+
+def parse(s: str) -> Expr:
+    return sqlglot.parse_one(s, read="snowflake")
+
+
+def type_id(s: str) -> int:
+    return statement_type.statement_type_id(parse(s))
+
+
+def test_statement_type_id_select() -> None:
+    assert type_id("select * from customers") == statement_type.SELECT
+    assert type_id("with c as (select 1) select * from c") == statement_type.SELECT
+
+
+def test_statement_type_id_dml() -> None:
+    assert type_id("insert into customers values (1)") == statement_type.INSERT
+    assert type_id("update customers set id = 1") == statement_type.UPDATE
+    assert type_id("delete from customers") == statement_type.DELETE
+    assert type_id("merge into t1 using t2 on t1.id = t2.id when matched then update set t1.id = 1") == (
+        statement_type.MERGE
+    )
+    assert type_id("insert all into t1 values (1) into t2 values (2) select 1") == statement_type.MULTI_INSERT
+    assert type_id("copy into customers from @stage1") == statement_type.COPY
+
+
+def test_statement_type_id_ddl() -> None:
+    assert type_id("create table customers (id int)") == statement_type.DDL
+    assert type_id("create or replace view v as select 1") == statement_type.DDL
+    assert type_id("create schema foobar") == statement_type.DDL
+    assert type_id("drop table customers") == statement_type.DDL
+    assert type_id("alter table customers add column name varchar") == statement_type.DDL
+    assert type_id("truncate table customers") == statement_type.DDL
+
+
+def test_statement_type_id_use() -> None:
+    assert type_id("use database foobar") == statement_type.USE_DATABASE
+    assert type_id("use schema foobar") == statement_type.USE_SCHEMA
+    assert type_id("use warehouse foobar") == statement_type.USE_WAREHOUSE
+    # other kinds fall back to the USE category
+    assert type_id("use role foobar") == statement_type.USE
+
+
+def test_statement_type_id_scl() -> None:
+    assert type_id("show tables") == statement_type.SHOW
+    assert type_id("describe table customers") == statement_type.DESCRIBE
+
+
+def test_statement_type_id_tcl() -> None:
+    assert type_id("begin") == statement_type.TCL
+    assert type_id("commit") == statement_type.TCL
+    assert type_id("rollback") == statement_type.TCL
+
+
+def test_statement_type_id_unknown() -> None:
+    assert type_id("put file:///tmp/customers.csv @stage1") == statement_type.UNKNOWN


### PR DESCRIPTION
Without `statementTypeId` the JDBC driver falls back to `SFStatementType.UNKNOWN`, which is flagged as generating a result set, so `executeUpdate` is rejected for every statement — DDL, DML and `USE` alike. The statement still runs, so rows get written and the caller sees an exception anyway. That blocks `JdbcTemplate.update()`, Hibernate and Flyway.

Adding the id on its own regresses the python connector: once it sees a DML type id it stops using `total` for rowcount and reads affected counts out of `rowset`, which we weren't sending because DML results went back as arrow. DML results are now returned as json instead, which is what real Snowflake does (checked against an account — details in #204). That also corrects `merge`, which reported the result row count (1) rather than rows inserted + updated (2).

Checked with snowflake-jdbc 4.3.2 against the server:

| | before | after |
|---|---|---|
| `executeUpdate` `INSERT ... VALUES (2),(3)` | exception | 2 |
| `executeUpdate` `UPDATE` / `DELETE` | exception | 1 |
| `executeUpdate` `USE SCHEMA` / DDL | exception | 0 |
| `PreparedStatement.executeUpdate` | exception | 1 |

Tests: statement type mapping unit tests, plus a server rowcount test covering insert/update/delete/merge whose values match a real Snowflake instance.

Fixes #204
