### PR TITLE
docs: how to connect with the JDBC driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,30 @@ SELECT 'Hello World' as greeting
 +-------------+
 ```
 
+#### Connecting from Java
+
+The official [snowflake-jdbc](https://github.com/snowflakedb/snowflake-jdbc) driver connects to the server unmodified:
+
+```
+jdbc:snowflake://<host>:<port>/?ssl=off&account=fakesnow&db=<database>&schema=<schema>
+```
+
+Two things to watch out for:
+
+- Keep `account` in the URL. Without it the driver derives the account from the host, which fails for hosts that have no account part, eg: `localhost`.
+- Run the JVM with `--add-opens=java.base/java.nio=ALL-UNNAMED`, otherwise the Arrow bundled in snowflake-jdbc can't initialise and queries fail with `ExceptionInInitializerError`.
+
+Using [Testcontainers](https://testcontainers.com):
+
+```java
+@Container
+static final GenericContainer<?> fakesnow =
+    new GenericContainer<>("ghcr.io/tekumara/fakesnow:latest").withExposedPorts(64616);
+
+String url = "jdbc:snowflake://" + fakesnow.getHost() + ":" + fakesnow.getMappedPort(64616)
+    + "/?ssl=off&account=fakesnow&db=db1&schema=schema1";
+```
+
 ### pytest fixtures
 
 fakesnow provides [fixtures](fakesnow/fixtures.py) for easier test integration. Add them in _conftest.py_:


### PR DESCRIPTION
The JDBC driver works against the server but the README doesn't mention it, and there are two non-obvious requirements that cost time to work out:

- `account` has to be in the URL. The driver derives it from the host otherwise, which fails for `localhost` and produces a confusing "claims to not accept jdbcUrl" error rather than a connection failure.
- The JVM needs `--add-opens=java.base/java.nio=ALL-UNNAMED` or the bundled Arrow throws `ExceptionInInitializerError` when the first result comes back.

Both came up wiring a Spring Boot service's integration tests to fakesnow via Testcontainers, replacing a Postgres substitute.
