### PR TITLE
fix: support JDBC driver setTimestamp

### DIFF
--- a/fakesnow/converter.py
+++ b/fakesnow/converter.py
@@ -21,8 +21,11 @@ def from_binding(binding: dict[str, str]) -> int | bytes | bool | date | time | 
         return from_date(value)
     elif type_ == "TIME":
         return from_time(value)
-    elif type_ == "TIMESTAMP_NTZ":
+    elif type_ in ("TIMESTAMP_NTZ", "TIMESTAMP_LTZ"):
+        # the JDBC driver binds setTimestamp as TIMESTAMP_LTZ, the python connector as TIMESTAMP_NTZ
         return from_datetime(value)
+    elif type_ == "TIMESTAMP_TZ":
+        return from_datetime_tz(value)
     else:
         # For other types, return str
         return value
@@ -58,3 +61,12 @@ def from_datetime(s: str) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(microseconds / 1_000_000, timezone.utc).replace(
         microsecond=int(microseconds % 1_000_000)
     )
+
+
+def from_datetime_tz(s: str) -> datetime.datetime:
+    """Convert a TIMESTAMP_TZ binding, ie: "<epoch nanoseconds> <utc offset in minutes + 1440>"."""
+    nanoseconds, _, offset_minutes = s.partition(" ")
+    at = from_datetime(nanoseconds)
+    if not offset_minutes:
+        return at
+    return at.astimezone(timezone(datetime.timedelta(minutes=int(offset_minutes) - 1440)))

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -3,7 +3,15 @@ import datetime
 
 import snowflake.connector.converter
 
-from fakesnow.converter import from_binary, from_boolean, from_date, from_datetime, from_time
+from fakesnow.converter import (
+    from_binary,
+    from_binding,
+    from_boolean,
+    from_date,
+    from_datetime,
+    from_datetime_tz,
+    from_time,
+)
 
 converter = snowflake.connector.converter.SnowflakeConverter()
 date_converter = converter._DATE_to_python({})
@@ -32,3 +40,19 @@ def test_from_time() -> None:
 def test_from_datetime() -> None:
     value = datetime.datetime(2023, 1, 2, 12, 30, 45, 123456, tzinfo=datetime.timezone.utc)
     assert from_datetime(converter._datetime_to_snowflake_bindings("TIMESTAMP_NTZ", value)) == value
+
+
+def test_from_binding_timestamps() -> None:
+    # the JDBC driver binds setTimestamp as TIMESTAMP_LTZ, the python connector as TIMESTAMP_NTZ
+    value = datetime.datetime(2023, 1, 2, 12, 30, 45, 123456, tzinfo=datetime.timezone.utc)
+    for type_ in ["TIMESTAMP_NTZ", "TIMESTAMP_LTZ", "TIMESTAMP_TZ"]:
+        binding = {"type": type_, "value": converter._datetime_to_snowflake_bindings(type_, value)}
+        assert from_binding(binding) == value, type_
+
+
+def test_from_datetime_tz() -> None:
+    # TIMESTAMP_TZ bindings carry the offset, as "<epoch nanoseconds> <offset minutes + 1440>"
+    value = datetime.datetime(2023, 1, 2, 12, 30, 45, 123456, tzinfo=datetime.timezone(datetime.timedelta(hours=9)))
+    converted = from_datetime_tz(converter._datetime_to_snowflake_bindings("TIMESTAMP_TZ", value))
+    assert converted == value
+    assert converted.utcoffset() == datetime.timedelta(hours=9)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -88,7 +88,8 @@ def test_server_binding_timestamp_ltz(server: dict) -> None:
 
         cur.execute("insert into example values (?)", (("TIMESTAMP_LTZ", timestamp),))
 
-        assert cur.execute("select value from example").fetchone() == (timestamp,)
+        cur.execute("select value from example")
+        assert cur.fetchone() == (timestamp,)
 
 
 def test_server_binding_named(server: dict) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -78,6 +78,19 @@ def test_server_binding_qmark(server: dict):
         cur.execute("select * from example where xint = ?", (1,))
 
 
+def test_server_binding_timestamp_ltz(server: dict) -> None:
+    with (
+        snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table example (value timestamp_ntz)")
+        timestamp = datetime.datetime(2026, 1, 1, 10)
+
+        cur.execute("insert into example values (?)", (("TIMESTAMP_LTZ", timestamp),))
+
+        assert cur.execute("select value from example").fetchone() == (timestamp,)
+
+
 def test_server_binding_named(server: dict) -> None:
     with snowflake.connector.connect(**server, database="DB1", schema="SCHEMA1") as conn:
         with conn.cursor() as cur:


### PR DESCRIPTION
`setTimestamp()` failed with a 500 for every timestamp column, because `from_binding` only converted `TIMESTAMP_NTZ`. The JDBC driver sends `setTimestamp` as `TIMESTAMP_LTZ`, so the epoch-nanoseconds string fell through to the `else` branch and reached duckdb unconverted:

```
_duckdb.ConversionException: Conversion Error: timestamp field value out of range: "1767229200000000000"
```

`TIMESTAMP_TZ` needed handling separately — the connector encodes it as `<epoch nanoseconds> <utc offset in minutes + 1440>`, so `int()` on the whole value fails.

Verified with snowflake-jdbc 3.19.0 against the server:

```
                 before   after
TIMESTAMP_NTZ    500      2026-01-01 01:00:00 Z
TIMESTAMP_LTZ    500      2026-01-01 01:00:00 Z
TIMESTAMP_TZ     500      2026-01-01 01:00:00 Z
TIMESTAMP        500      2026-01-01 01:00:00 Z
```

That's the same instant a real account returns for the same binding — `2025-12-31 17:00:00.000 -0800` on a session in `America/Los_Angeles` — only the rendering timezone differs.

`setDate` and `setTime` were already fine, and `setTime` matches real Snowflake including the timezone shift.

Fixes #374
