### PR TITLE
fix: accept a space before a utc offset in timestamp literals

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -280,6 +280,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.sequence_nextval)
             .transform(transforms.values_columns)
             .transform(transforms.to_date)
+            .transform(transforms.timestamp_offsets)
             .transform(transforms.to_decimal)
             .transform(transforms.to_timestamp)
             .transform(transforms.to_variant)
@@ -428,6 +429,11 @@ class FakeSnowflakeCursor:
             raise snowflake.connector.errors.DatabaseError(msg=e.args[0], errno=250002, sqlstate="08003") from e
         except duckdb.ParserException as e:
             raise snowflake.connector.errors.ProgrammingError(msg=e.args[0], errno=1003, sqlstate="42000") from e
+        except duckdb.ConversionException as e:
+            # a value that can't be cast, eg: a time zone name snowflake wouldn't accept either.
+            # snowflake reports this as an error rather than failing, message content may differ.
+            msg = cast(str, e.args[0]).split("\n")[0]
+            raise snowflake.connector.errors.ProgrammingError(msg=msg, errno=100035, sqlstate="22007") from e
 
         affected_count = None
 

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -72,6 +72,7 @@ from fakesnow.transforms.transforms import (
     split as split,
     tag as tag,
     timestamp_ntz as timestamp_ntz,
+    timestamp_offsets as timestamp_offsets,
     to_date as to_date,
     to_decimal as to_decimal,
     to_timestamp as to_timestamp,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1659,3 +1659,39 @@ def numeric_agg_implicit_cast(expression: Expr) -> Expr:
         if col_name and isinstance(expression.parent, exp.Select):
             return exp.alias_(expression, col_name, quoted=True)
     return expression
+
+
+# a numeric utc offset at the end of a timestamp literal, ie: " +09:00", " -0700", " Z"
+TIMESTAMP_OFFSET = re.compile(r"(\d)\s+([+-]\d{2}:?(?:\d{2})?|Z)$")
+
+TIMESTAMP_WITH_OFFSET_TYPES = (
+    exp.DataType.Type.TIMESTAMPTZ,
+    exp.DataType.Type.TIMESTAMPLTZ,
+)
+
+
+def timestamp_offsets(expression: Expr) -> Expr:
+    """Remove the space before a numeric utc offset in a timestamp literal.
+
+    Snowflake accepts a space, duckdb doesn't and reads the offset as a time zone name:
+
+        "2026-01-01 10:00:00 +09:00" -> Unknown TimeZone '+09:00'
+
+    so it's dropped before duckdb sees it.
+
+        SELECT '2026-01-01 10:00:00 +09:00'::TIMESTAMP_TZ
+    becomes
+        SELECT '2026-01-01 10:00:00+09:00'::TIMESTAMPTZ
+    """
+    if (
+        isinstance(expression, exp.Cast)
+        and expression.to.this in TIMESTAMP_WITH_OFFSET_TYPES
+        and isinstance(expression.this, exp.Literal)
+        and expression.this.is_string
+    ):
+        literal = expression.this
+        collapsed = TIMESTAMP_OFFSET.sub(r"\1\2", literal.this)
+        if collapsed != literal.this:
+            literal.set("this", collapsed)
+
+    return expression

--- a/tests/test_timestamp.py
+++ b/tests/test_timestamp.py
@@ -2,6 +2,7 @@
 
 import datetime
 
+import pytest
 import snowflake.connector
 
 # see https://docs.snowflake.com/en/sql-reference/functions/to_timestamp
@@ -61,3 +62,34 @@ def test_string_datetime_to_timestamp(cur: snowflake.connector.cursor.SnowflakeC
 
     cur.execute("SELECT to_timestamp_ntz('2013-04-05 01:02:03')")
     assert cur.fetchall() == [(datetime.datetime(2013, 4, 5, 1, 2, 3),)]
+
+
+def test_timestamp_tz_with_offset(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # snowflake accepts a numeric utc offset, with or without a space before it, and in
+    # both TZH:TZM and TZHTZM forms. see
+    # https://docs.snowflake.com/en/sql-reference/date-time-input-output
+    for literal in [
+        "2026-01-01 10:00:00 +09:00",
+        "2026-01-01 10:00:00+09:00",
+        "2026-01-01 10:00:00 +0900",
+        "2026-01-01T10:00:00+09:00",
+    ]:
+        assert cur.execute(f"select '{literal}'::timestamp_tz").fetchall() == [
+            (datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9))),)
+        ], literal
+
+    assert cur.execute("select '2026-01-01 10:00:00 -0700'::timestamp_tz").fetchall() == [
+        (datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=-7))),)
+    ]
+
+    assert cur.execute("select to_timestamp_tz('2026-01-01 10:00:00 +09:00')").fetchall() == [
+        (datetime.datetime(2026, 1, 1, 10, 0, tzinfo=datetime.timezone(datetime.timedelta(hours=9))),)
+    ]
+
+
+def test_timestamp_tz_with_unrecognised_zone(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # snowflake only takes numeric offsets here, a zone name is an error not a failure
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+        cur.execute("select '2026-01-01 10:00:00 Not/AZone'::timestamp_tz")
+
+    assert excinfo.value.sqlstate == "22007"


### PR DESCRIPTION
Two parts, both from #372.

**The space.** Snowflake takes `'2026-01-01 10:00:00 +09:00'`, duckdb reads the offset as a time zone name and raises `Unknown TimeZone '+09:00'`. It parses the same value fine without the space, so `timestamp_offsets` drops it for string literals cast to `timestamp_tz` or `timestamp_ltz`, which also covers `to_timestamp_tz()`. All four shapes Snowflake documents now work, and the offset is applied rather than ignored.

**The 500.** `ConversionException` wasn't in the list of duckdb exceptions translated in `_execute`, so anything it raised surfaced as a server error. Clients treat that as retryable: the python connector repeated one failing insert 333 times, the JDBC driver 7. It's now a `ProgrammingError` with `100035 / 22007`, which is what a real account returns for an unrecognised timestamp.

Not covered: a literal in `INSERT INTO t VALUES ('2026-01-01 10:00:00 +09:00')`. There's no cast to hang the rewrite off, and knowing the target column type means reaching for the schema, which the transforms don't do. It fails with the error above rather than a 500 now. Happy to look at it if you have a preference for how, otherwise it seemed better left out of this change.

Rendering the stored offset back is still option 2, untouched here.

Refs #372
