### PR TITLE
fix: honour overwrite in write_pandas

### DIFF
--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -70,7 +70,14 @@ def write_pandas(
     if auto_create_table:
         cols = [f"{c} {sql_type(t)}" for c, t in df.dtypes.to_dict().items()]
 
+        if overwrite:
+            # overwrite drops and recreates the table, so its schema matches the dataframe
+            conn.cursor().execute(f"DROP TABLE IF EXISTS {name}")
+
         conn.cursor().execute(f"CREATE TABLE IF NOT EXISTS {name} ({','.join(cols)})")
+    elif overwrite:
+        # overwrite truncates the existing table before loading
+        conn.cursor().execute(f"TRUNCATE TABLE {name}")
 
     count = _insert_df(conn._duck_conn, df, name)  # noqa: SLF001
 

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -156,6 +156,38 @@ def test_write_pandas_db_schema(conn: snowflake.connector.SnowflakeConnection):
         assert cur.fetchall() == [(1, "Jenny", None), (2, "Jasper", None)]
 
 
+def test_write_pandas_overwrite(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        cur.execute("create table customers (ID int, FIRST_NAME varchar)")
+
+        df = pd.DataFrame.from_records([{"ID": 1, "FIRST_NAME": "Jenny"}])
+        snowflake.connector.pandas_tools.write_pandas(conn, df, "CUSTOMERS")
+
+        df2 = pd.DataFrame.from_records([{"ID": 2, "FIRST_NAME": "Jasper"}])
+        snowflake.connector.pandas_tools.write_pandas(conn, df2, "CUSTOMERS", overwrite=True)
+
+        cur.execute("select id, first_name from customers")
+
+        # existing rows are replaced, not appended to
+        assert cur.fetchall() == [(2, "Jasper")]
+
+
+def test_write_pandas_overwrite_auto_create(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        cur.execute("create table customers (ID int, AGE int)")
+
+        df = pd.DataFrame.from_records([{"ID": 1, "AGE": 20}])
+        snowflake.connector.pandas_tools.write_pandas(conn, df, "CUSTOMERS", auto_create_table=True)
+
+        df2 = pd.DataFrame.from_records([{"ID": 2, "AGE": 30}])
+        snowflake.connector.pandas_tools.write_pandas(conn, df2, "CUSTOMERS", auto_create_table=True, overwrite=True)
+
+        cur.execute("select id, age from customers")
+
+        # the table is dropped and recreated, so only the new rows remain
+        assert cur.fetchall() == [(2, 30)]
+
+
 def sort_keys(sdict: str, indent: int | None = 2) -> str:
     return json.dumps(
         json.loads(sdict, object_pairs_hook=lambda x: dict(sorted(x))),


### PR DESCRIPTION
Closes #290

`write_pandas` accepted an `overwrite` parameter but never used it, so rows were always appended. With `overwrite=True` the table is now truncated first, or dropped and recreated when `auto_create_table` is also set, matching snowflake-connector-python.

This change was prepared with AI assistance; the regression tests were run locally and fail without the fix.
