### PR TITLE
fix: support array bindings, ie: executemany over the server

### DIFF
--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -195,7 +195,7 @@ async def query_request(request: Request) -> JSONResponse:
                         {"name": "TIMEZONE", "value": "Etc/UTC"},
                     ],
                     "rowtype": rowtype,
-                    "total": batch_rowcount if batch is not None else cur._rowcount,  # noqa: SLF001
+                    "total": 1 if batch is not None else cur._rowcount,  # noqa: SLF001
                     "queryId": cur.sfqid,
                     "statementTypeId": type_id,
                     "finalDatabaseName": conn.database,

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -68,6 +68,9 @@ async def login_request(request: Request) -> JSONResponse:
                 "parameters": [
                     {"name": "AUTOCOMMIT", "value": autocommit},
                     {"name": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY", "value": 3600},
+                    # clients read this to decide whether to bind an array inline or stage it
+                    # first. 0 keeps them inline, ie: no PUT, which we don't support well yet.
+                    {"name": "CLIENT_STAGE_ARRAY_BINDING_THRESHOLD", "value": 0},
                 ],
                 "sessionInfo": {
                     "databaseName": database,
@@ -91,23 +94,44 @@ async def query_request(request: Request) -> JSONResponse:
 
         sql_text = body_json["sqlText"]
 
+        params: Any = None
+        # rows of params, when the client sends an array binding
+        batch: list[tuple[Any, ...]] | None = None
+
         if bindings := body_json.get("bindings"):
-            if all(k.isdigit() for k in bindings):
-                # positional bindings: {'1': {'type': 'FIXED', 'value': '10'}, ...} -> tuple (10, ...)
-                params = tuple(from_binding(bindings[str(pos)]) for pos in range(1, len(bindings) + 1))
-            else:
+            if not all(k.isdigit() for k in bindings):
                 # named bindings: {'myid': {'type': 'FIXED', 'value': '10'}, ...} -> dict {'myid': 10, ...}
                 params = {name: from_binding(b) for name, b in bindings.items()}
-            logger.debug(f"Bindings: {params}")
-        else:
-            params = None
+            elif any(isinstance(b["value"], list) for b in bindings.values()):
+                # array bindings hold a list of values per placeholder, one per row, and are sent
+                # when executing a batch, eg: cursor.executemany. transpose them into rows, ie:
+                # {'1': {'type': 'FIXED', 'value': ['1', '2']}, ...} -> [(1, ...), (2, ...)]
+                columns = [
+                    [from_binding({**b, "value": v}) for v in b["value"]]
+                    for b in (bindings[str(pos)] for pos in range(1, len(bindings) + 1))
+                ]
+                batch = list(zip(*columns, strict=True))
+            else:
+                # positional bindings: {'1': {'type': 'FIXED', 'value': '10'}, ...} -> tuple (10, ...)
+                params = tuple(from_binding(bindings[str(pos)]) for pos in range(1, len(bindings) + 1))
+            logger.debug(f"Bindings: {batch if batch is not None else params}")
 
         expr = parse_one(sql_text, read="snowflake")
         type_id = statement_type_id(expr)
 
+        batch_rowcount = 0
+
         try:
             # only a single sql statement is sent at a time by the python snowflake connector
-            cur = await run_in_threadpool(conn.cursor().execute, sql_text, binding_params=params, server=True)
+            cur = conn.cursor()
+            if batch is None:
+                await run_in_threadpool(cur.execute, sql_text, binding_params=params, server=True)
+            else:
+                # snowflake runs an array binding as one statement and reports the rows affected
+                # across the whole batch, so accumulate them as we execute row by row
+                for row in batch:
+                    await run_in_threadpool(cur.execute, sql_text, binding_params=row, server=True)
+                    batch_rowcount += cur._rowcount or 0  # noqa: SLF001
             rowtype = describe_as_rowtype(cur._describe_last_sql())  # noqa: SLF001
 
             expr = cur._last_transformed  # noqa: SLF001
@@ -145,10 +169,13 @@ async def query_request(request: Request) -> JSONResponse:
 
         arrow_table = cur._arrow_table  # noqa: SLF001
 
-        if arrow_table and type_id in DML_TYPE_IDS:
+        if batch is not None and arrow_table and type_id in DML_TYPE_IDS:
+            # the batch ran as multiple statements, but the client sent one, so report the total
+            result: dict[str, Any] = {"queryResultFormat": "json", "rowset": [[str(batch_rowcount)]]}
+        elif arrow_table and type_id in DML_TYPE_IDS:
             # DML results are returned as json, because clients read the affected row counts
             # from rowset, eg: SnowflakeCursor._init_result_and_meta
-            result: dict[str, Any] = {
+            result = {
                 "queryResultFormat": "json",
                 "rowset": [
                     [None if v is None else str(v) for v in row]
@@ -168,7 +195,7 @@ async def query_request(request: Request) -> JSONResponse:
                         {"name": "TIMEZONE", "value": "Etc/UTC"},
                     ],
                     "rowtype": rowtype,
-                    "total": cur._rowcount,  # noqa: SLF001
+                    "total": batch_rowcount if batch is not None else cur._rowcount,  # noqa: SLF001
                     "queryId": cur.sfqid,
                     "statementTypeId": type_id,
                     "finalDatabaseName": conn.database,

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -161,6 +161,26 @@ def test_server_client_session_keep_alive(server: dict) -> None:
         pass
 
 
+def test_server_executemany_qmark(server: dict) -> None:
+    # the connector reads CLIENT_STAGE_ARRAY_BINDING_THRESHOLD from the login response to decide
+    # between binding the values inline and staging them, then sends the inline values as an
+    # array binding, ie: a list of values per placeholder
+    with (
+        snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table example (id int, name varchar)")
+        cur.executemany("insert into example values (?, ?)", [(1, "one"), (2, "two"), (3, "three")])
+        assert cur.rowcount == 3
+
+        cur.execute("select id, name from example order by id")
+        assert cur.fetchall() == [
+            (1, "one"),
+            (2, "two"),
+            (3, "three"),
+        ]
+
+
 def test_server_close(server: dict) -> None:
     conn = snowflake.connector.connect(**server)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -170,6 +170,7 @@ def test_server_executemany_qmark(server: dict) -> None:
         snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
         conn.cursor() as cur,
     ):
+        assert conn.rest
         responses = []
         request = conn.rest.request
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,6 +5,7 @@ import os
 import tempfile
 import uuid
 from decimal import Decimal
+from typing import Any
 from unittest.mock import patch
 
 import numpy as np
@@ -169,9 +170,22 @@ def test_server_executemany_qmark(server: dict) -> None:
         snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
         conn.cursor() as cur,
     ):
+        responses = []
+        request = conn.rest.request
+
+        def capture_response(*args: Any, **kwargs: Any):
+            response = request(*args, **kwargs)
+            body = kwargs.get("body", args[1] if len(args) > 1 else None)
+            if body and body.get("sqlText", "").startswith("insert into example"):
+                responses.append(response)
+            return response
+
+        conn.rest.request = capture_response
         cur.execute("create or replace table example (id int, name varchar)")
         cur.executemany("insert into example values (?, ?)", [(1, "one"), (2, "two"), (3, "three")])
         assert cur.rowcount == 3
+        # Snowflake's response has one result row; the affected-row count is in rowset.
+        assert responses[-1]["data"]["total"] == 1
 
         cur.execute("select id, name from example order by id")
         assert cur.fetchall() == [


### PR DESCRIPTION
Part 2 of #371, the python connector half. `describeOnly` is untouched, I'll send that separately.

**The threshold.** Clients read `CLIENT_STAGE_ARRAY_BINDING_THRESHOLD` from the login response to decide whether to bind an array inline or stage it first. It wasn't there, so `executemany` died with `KeyError: 'CLIENT_STAGE_ARRAY_BINDING_THRESHOLD'` before sending anything. Returning 0 keeps the values inline and avoids the PUT, as you suggested.

**The array binding.** With the threshold in place the connector gets further and sends the values, which turned out to be the second half of the problem. An array binding is one list per placeholder rather than one value:

```
{'1': {'type': 'FIXED', 'value': ['1', '2', '3']}, '2': {'type': 'TEXT', 'value': ['one', 'two', 'three']}}
```

`from_binding` assumed a scalar, so `int(value)` got a list and the request 500'd. They're now transposed into rows and executed one at a time, the same tradeoff `cursor.executemany` already makes locally.

The rowcount needed handling because of that: the client sent one statement and expects one answer. Snowflake returns a single `number of rows inserted` for the whole batch, 3 for three rows, so the per-row counts are summed rather than reporting the last one.

Verified end to end against the python connector with `paramstyle="qmark"`. The JDBC driver takes the same path but stops earlier on `describeOnly`, so it stays broken until part 1 lands.

Refs #371
