### PR TITLE
fix: describe statements without running them for describeOnly requests

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -64,6 +64,15 @@ SQL_COPY_ROWS = Template(
 )
 
 
+# The result columns snowflake reports when asked to describe a DML statement without running it.
+# The counts are placeholders, only the column names and types are used.
+DESCRIBE_RESULT_SQL: dict[type[Expr], str] = {
+    exp.Insert: SQL_INSERTED_ROWS.substitute(count=0),
+    exp.Update: SQL_UPDATED_ROWS.substitute(count=0),
+    exp.Delete: SQL_DELETED_ROWS.substitute(count=0),
+}
+
+
 class FakeSnowflakeCursor:
     def __init__(
         self,
@@ -135,6 +144,31 @@ class FakeSnowflakeCursor:
     @property
     def description(self) -> list[ResultMetadata]:
         return describe_as_result_metadata(self._describe_last_sql())
+
+    def _describe_only(self, command: str) -> list | None:
+        """Describe the result columns of command without executing it.
+
+        Snowflake does this for describeOnly requests, which clients send before executing a
+        prepared statement, eg: the JDBC driver before a batch insert.
+
+        Returns None for statements we can only describe by running them.
+        """
+
+        expression = sqlglot.parse_one(command, read="snowflake")
+
+        if result_sql := DESCRIBE_RESULT_SQL.get(type(expression)):
+            describe = result_sql
+        elif isinstance(expression, exp.Select):
+            # a describe request carries no bindings, so replace the placeholders with null to
+            # make the statement runnable. it doesn't change the columns the query returns.
+            describe = expression.transform(lambda e: exp.Null() if isinstance(e, exp.Placeholder) else e).sql(
+                dialect="snowflake"
+            )
+        else:
+            return None
+
+        self.execute(f"DESCRIBE {describe}")
+        return self.fetchall()
 
     def _describe_last_sql(self) -> list:
         # use a separate cursor to avoid consuming the result set on this cursor

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -9,19 +9,21 @@ from dataclasses import dataclass
 from typing import Any
 
 import snowflake.connector.errors
-from sqlglot import parse_one
+from sqlglot import Expr, exp, parse_one
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 
+from fakesnow import statement_type
 from fakesnow.arrow import to_ipc, to_sf
 from fakesnow.converter import from_binding
+from fakesnow.cursor import FakeSnowflakeCursor
 from fakesnow.expr import normalise_ident
 from fakesnow.fakes import FakeSnowflakeConnection
 from fakesnow.instance import FakeSnow
-from fakesnow.rowtype import describe_as_rowtype
+from fakesnow.rowtype import ColumnInfo, describe_as_rowtype
 from fakesnow.statement_type import DML_TYPE_IDS, statement_type_id
 
 logger = logging.getLogger("fakesnow.server")
@@ -119,6 +121,12 @@ async def query_request(request: Request) -> JSONResponse:
         expr = parse_one(sql_text, read="snowflake")
         type_id = statement_type_id(expr)
 
+        if body_json.get("describeOnly"):
+            cur = conn.cursor()
+            if (described := await run_in_threadpool(cur._describe_only, sql_text)) is not None:  # noqa: SLF001
+                return describe_only_response(conn, cur, describe_as_rowtype(described), expr, type_id)
+            # we can only describe this statement by running it, which is what we've always done
+
         batch_rowcount = 0
 
         try:
@@ -211,6 +219,42 @@ async def query_request(request: Request) -> JSONResponse:
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
         )
+
+
+def describe_only_response(
+    conn: FakeSnowflakeConnection,
+    cur: FakeSnowflakeCursor,
+    rowtype: list[ColumnInfo],
+    expr: Expr,
+    type_id: int,
+) -> JSONResponse:
+    """Describe the statement's result without any rows, as snowflake does for describeOnly."""
+
+    # snowflake returns json for everything but a query
+    result = (
+        {"queryResultFormat": "arrow", "rowsetBase64": ""}
+        if type_id == statement_type.SELECT
+        else {"queryResultFormat": "json", "rowset": []}
+    )
+    return JSONResponse(
+        {
+            "data": {
+                "rowtype": rowtype,
+                "total": 0,
+                "returned": 0,
+                "queryId": cur.sfqid,
+                "statementTypeId": type_id,
+                "numberOfBinds": len(list(expr.find_all(exp.Placeholder))),
+                # clients read this to decide whether they can send the batch as an array binding.
+                # snowflake only supports it for inserts.
+                "arrayBindSupported": type_id == statement_type.INSERT,
+                "finalDatabaseName": conn.database,
+                "finalSchemaName": conn.schema,
+                **result,
+            },
+            "success": True,
+        }
+    )
 
 
 def to_token(request: Request) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -626,3 +626,28 @@ def test_server_monitoring_endpoint_error(scur: snowflake.connector.cursor.Snowf
     ) as exc:
         cur.fetchall()
     assert exc.value.errno == -1
+
+
+def test_server_describe_only(server: dict) -> None:
+    # clients describe a statement before executing it, eg: the JDBC driver before a batch
+    # insert, and expect the result columns back without the statement having run
+    with (
+        snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table example (id int, name varchar)")
+
+        assert [(m.name, m.type_code) for m in cur.describe("select id, name from example where id = ?")] == [
+            ("ID", 0),
+            ("NAME", 2),
+        ]
+        assert [m.name for m in cur.describe("insert into example values (?, ?)")] == ["number of rows inserted"]
+        assert [m.name for m in cur.describe("update example set name = ? where id = ?")] == [
+            "number of rows updated",
+            "number of multi-joined rows updated",
+        ]
+        assert [m.name for m in cur.describe("delete from example where id = ?")] == ["number of rows deleted"]
+
+        # nothing ran
+        cur.execute("select count(*) from example")
+        assert cur.fetchall() == [(0,)]


### PR DESCRIPTION
Part 1 of #371. #383 is the other half.

`describeOnly=true` was ignored, so we ran the statement. A describe request carries no bindings, so `insert into example values (?, ?)` arrived with `params=None` and 500'd, which the JDBC driver retried 6 times before giving up.

Now we describe without running. For DML the result columns are the affected row counts, which we already have as SQL, so those get described instead of the statement. For a query the placeholders are replaced with null, which makes it describable without changing the columns it returns.

I checked the response against an account to see what to send back:

| statement | rowtype | arrayBindSupported |
| --- | --- | --- |
| insert | number of rows inserted | true |
| update | number of rows updated, number of multi-joined rows updated | false |
| delete | number of rows deleted | false |
| merge | number of rows inserted, number of rows updated | false |
| create table | status | false |
| select | the query's columns | false |

Snowflake sends `total: 0`, no rows, and json for everything except a query. It also sends `numberOfBinds` and `arrayBindSupported`, which is the field clients read to decide whether they can send a batch as an array binding, and it's only true for inserts. Our existing DML result SQL already produces those exact column names, so the rowtypes line up.

Not covered: statements we can only describe by running, ie: MERGE, SHOW and DDL. MERGE derives its columns from the rows it matched, and SHOW and DDL build their result during execution. They fall through to the old behaviour rather than erroring, so they're no worse than before. Happy to take those on separately if you want them.

With both parts a JDBC batch insert works end to end, `executeBatch` returns `[1, 1, 1]` and the rows land.

Fixes #371
