### PR TITLE
fix: typed CTAS with aliased SELECT expression

### DIFF
--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1375,8 +1375,6 @@ def create_table_as(expression: Expr, duck_conn: DuckDBPyConnection) -> Expr:
             create_col_type = col_def.kind
             select_col = select_query.expressions[i]
 
-            # Unwrap an existing Alias so we cast the value, not `val AS alias`.
-            # Otherwise DuckDB receives invalid SQL like `CAST(1 AS ID AS BIGINT)`.
             inner = select_col.this if isinstance(select_col, exp.Alias) else select_col
             cast_expr = exp.Cast(this=inner, to=create_col_type)
             aliased_expr = exp.Alias(this=cast_expr, alias=create_col_id)

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1375,7 +1375,10 @@ def create_table_as(expression: Expr, duck_conn: DuckDBPyConnection) -> Expr:
             create_col_type = col_def.kind
             select_col = select_query.expressions[i]
 
-            cast_expr = exp.Cast(this=select_col, to=create_col_type)
+            # Unwrap an existing Alias so we cast the value, not `val AS alias`.
+            # Otherwise DuckDB receives invalid SQL like `CAST(1 AS ID AS BIGINT)`.
+            inner = select_col.this if isinstance(select_col, exp.Alias) else select_col
+            cast_expr = exp.Cast(this=inner, to=create_col_type)
             aliased_expr = exp.Alias(this=cast_expr, alias=create_col_id)
 
             new_expressions.append(aliased_expr)

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -187,6 +187,14 @@ def test_create_table_as(dcur: snowflake.connector.cursor.SnowflakeCursor) -> No
     dcur.execute("select * from t1")
     assert dcur.fetchall() == [{"ID": "1"}]
 
+    # Typed column list + SELECT aliases previously emitted
+    # `CAST(1 AS ID AS BIGINT) AS ID` which DuckDB rejects.
+    dcur.execute(
+        "create or replace table t1(id int, payload variant) as select 1 as id, parse_json('{\"a\":1}') as payload"
+    )
+    dcur.execute("select id, payload from t1")
+    assert dcur.fetchall() == [{"ID": 1, "PAYLOAD": '{"a":1}'}]
+
 
 def test_dateadd_date_cast(dcur: snowflake.connector.DictCursor):
     q = """

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -191,7 +191,7 @@ def test_create_table_as(dcur: snowflake.connector.cursor.SnowflakeCursor) -> No
         "create or replace table t1(id int, payload variant) as select 1 as id, parse_json('{\"a\":1}') as payload"
     )
     dcur.execute("select id, payload from t1")
-    assert dcur.fetchall() == [{"ID": 1, "PAYLOAD": '{"a":1}'}]
+    assert dindent(dcur.fetchall()) == [{"ID": 1, "PAYLOAD": '{\n  "a": 1\n}'}]
 
 
 def test_dateadd_date_cast(dcur: snowflake.connector.DictCursor):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -187,8 +187,6 @@ def test_create_table_as(dcur: snowflake.connector.cursor.SnowflakeCursor) -> No
     dcur.execute("select * from t1")
     assert dcur.fetchall() == [{"ID": "1"}]
 
-    # Typed column list + SELECT aliases previously emitted
-    # `CAST(1 AS ID AS BIGINT) AS ID` which DuckDB rejects.
     dcur.execute(
         "create or replace table t1(id int, payload variant) as select 1 as id, parse_json('{\"a\":1}') as payload"
     )


### PR DESCRIPTION
## Summary

Typed CTAS statements with aliased SELECT expressions fail even though they are valid Snowflake SQL

Fixes #385 

## Details

`create_table_as` wraps each SELECT expression in `CAST(... AS <declared_type>)` then re-aliases it to the declared column name. When the SELECT expression is already an `Alias` (`1 AS id`), that becomes invalid DuckDB:

```sql
-- input
CREATE TABLE t (id INT, payload VARIANT) AS
SELECT 1 AS id, parse_json('{"a":1}') AS payload

-- before (broken)
CAST(1 AS ID AS BIGINT) AS ID, CAST(JSON(...) AS PAYLOAD AS JSON) AS PAYLOAD

-- after
CAST(1 AS BIGINT) AS ID, CAST(JSON(...) AS JSON) AS PAYLOAD
```

Fix: unwrap `exp.Alias` before casting so we cast the value, then alias.

## Test plan

- [x] Extended `test_create_table_as` with the previously-failing typed-cols + SELECT-aliases form
- [x] `pytest tests/test_fakes.py::test_create_table_as` passes locally


Made with [Cursor](https://cursor.com)