### PR TITLE
fix: support bind params and a values list source in MERGE

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -177,9 +177,11 @@ class FakeSnowflakeCursor:
             expression = parse_one(command, read="snowflake")
             self.check_db_and_schema(expression)
 
-            for exp in self._transform_explode(expression):
-                transformed = self._transform(exp, params)
-                self._execute(transformed, params)
+            for statement in self._transform_explode(expression):
+                transformed = self._transform(statement, params)
+                # a statement split into several, eg: MERGE, keeps the placeholders in whichever
+                # part reads the source rows. duckdb rejects params for the parts without any.
+                self._execute(transformed, params if transformed.find(exp.Placeholder) else None)
 
             if not kwargs.get("server") and (put_stage_data := transformed.args.get("put_stage_data")):  # pyright: ignore[reportPossiblyUnboundVariable]
                 self._put_files(put_stage_data)

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -22,7 +22,13 @@ def _create_merge_candidates(merge_expr: exp.Merge) -> Expr:
 
     source = merge_expr.args.get("using")
     assert isinstance(source, Expr)
-    source_id = (alias := source.args.get("alias")) and alias.this if isinstance(source, exp.Subquery) else source.this
+    # a source is either a table, or a subquery or values list that carries its name in an alias,
+    # eg: USING (VALUES (1, 'a')) AS s (id, name)
+    source_id = (
+        (alias := source.args.get("alias")) and alias.this
+        if isinstance(source, (exp.Subquery, exp.Values))
+        else source.this
+    )
     assert isinstance(source_id, exp.Identifier)
 
     join_expr = merge_expr.args.get("on")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -582,3 +582,54 @@ def test_merge_with_source_subquery(conn: snowflake.connector.SnowflakeConnectio
         {"ID": 1, "BATCH_NUMBER": 1, "ACTIVE_STATUS": 1, "END_DATE": datetime.date(2001, 1, 1)},
         {"ID": 2, "BATCH_NUMBER": 2, "ACTIVE_STATUS": 1, "END_DATE": None},
     ]
+
+
+def test_merge_with_bind_params(_fakesnow: None) -> None:
+    # a MERGE is split into several statements, and only the one reading the source rows keeps
+    # the placeholders. binding the params to all of them fails with a count mismatch.
+    with (
+        snowflake.connector.connect(database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table t (id int, name varchar)")
+        cur.execute("insert into t values (1, 'old')")
+
+        merge = """
+            MERGE INTO t tgt USING (SELECT ? AS id, ? AS name) src ON tgt.id = src.id
+            WHEN MATCHED THEN UPDATE SET tgt.name = src.name
+            WHEN NOT MATCHED THEN INSERT (id, name) VALUES (src.id, src.name)
+            """
+
+        cur.execute(merge, (1, "updated"))
+        assert cur.fetchall() == [(0, 1)]
+
+        cur.execute(merge, (2, "inserted"))
+        assert cur.fetchall() == [(1, 0)]
+
+        cur.execute("select id, name from t order by id")
+        assert cur.fetchall() == [(1, "updated"), (2, "inserted")]
+
+
+def test_merge_with_values_source(_fakesnow: None) -> None:
+    # a values list carries its name in an alias, like a subquery, rather than in .this
+    with (
+        snowflake.connector.connect(database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table t (id int, name varchar)")
+        cur.execute("insert into t values (1, 'old')")
+
+        merge = """
+            MERGE INTO t tgt USING (VALUES (?, ?)) src (id, name) ON tgt.id = src.id
+            WHEN MATCHED THEN UPDATE SET tgt.name = src.name
+            WHEN NOT MATCHED THEN INSERT (id, name) VALUES (src.id, src.name)
+            """
+
+        cur.execute(merge, (1, "updated"))
+        assert cur.fetchall() == [(0, 1)]
+
+        cur.execute(merge, (2, "inserted"))
+        assert cur.fetchall() == [(1, 0)]
+
+        cur.execute("select id, name from t order by id")
+        assert cur.fetchall() == [(1, "updated"), (2, "inserted")]


### PR DESCRIPTION
Two independent causes behind #387, both giving a 500.

**Params bound to every part of a split statement.** A MERGE becomes four statements, and only the one building `merge_candidates` keeps the placeholders. The same params were bound to all four, so the other three failed with `Parameter argument/count mismatch, identifiers of the excess parameters: 1, 2`. They're now bound to the parts that have placeholders.

This is why the issue reported that any bind parameter breaks a MERGE, while a bound INSERT is fine: an INSERT isn't split.

**A values list as the source.** `USING (VALUES (1, 'a')) AS s (id, name)` parses to `exp.Values`, not `exp.Subquery`, and only a subquery was checked for the alias, so the name was read from `.this`, wasn't an `Identifier`, and the assert blew up.

Worth noting this one has nothing to do with binds, it fails with literals too:

```sql
MERGE INTO t tgt USING (VALUES (1, 'x')) src (id, name) ON tgt.id = src.id
WHEN MATCHED THEN UPDATE SET tgt.name = src.name
```

I checked all three shapes from the issue against an account and Snowflake accepts them, including the values list.

Reproduces without the server, on `paramstyle="qmark"`, so the tests are in `test_merge.py` rather than `test_server.py`. Also confirmed through the JDBC driver, which is where it was found: all three variants pass now, previously two retried into a 500 and one hit the assert.

Fixes #387
