### PR TITLE
feat: support structured types (by treating as JSON without their element types)

### DIFF
--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1269,6 +1269,10 @@ def try_parse_json(expression: Expr) -> Expr:
 def semi_structured_types(expression: Expr) -> Expr:
     """Convert OBJECT, ARRAY, and VARIANT types to duckdb compatible types.
 
+    Structured types, eg: ARRAY(VARCHAR) or OBJECT(a INT), become JSON too. Their
+    element types aren't carried over, because duckdb would read them as a type
+    modifier and reject them, ie: JSON(TEXT).
+
     Example:
         >>> import sqlglot
         >>> sqlglot.parse_one("CREATE TABLE table1 (name object)").transform(semi_structured_types).sql()
@@ -1285,9 +1289,7 @@ def semi_structured_types(expression: Expr) -> Expr:
         exp.DataType.Type.OBJECT,
         exp.DataType.Type.VARIANT,
     ]:
-        new = expression.copy()
-        new.args["this"] = exp.DataType.Type.JSON
-        return new
+        return exp.DataType(this=exp.DataType.Type.JSON, nested=False)
 
     return expression
 

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1269,9 +1269,9 @@ def try_parse_json(expression: Expr) -> Expr:
 def semi_structured_types(expression: Expr) -> Expr:
     """Convert OBJECT, ARRAY, and VARIANT types to duckdb compatible types.
 
-    Structured types, eg: ARRAY(VARCHAR) or OBJECT(a INT), become JSON too. Their
-    element types aren't carried over, because duckdb would read them as a type
-    modifier and reject them, ie: JSON(TEXT).
+    Structured types, eg: ARRAY(VARCHAR) or OBJECT(a INT NOT NULL), become JSON
+    too. Their element types and field constraints aren't carried over, because
+    duckdb would read them as a type modifier and reject them, ie: JSON(TEXT).
 
     Example:
         >>> import sqlglot

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -157,19 +157,19 @@ def test_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("select names from structured")
     assert indent(cur.fetchall()) == [('[\n  "A",\n  "B"\n]',)]
 
-    cur.execute("select names[0] from structured")
-    assert cur.fetchall() == [('"A"',)]
+    cur.execute("select names[0]::varchar from structured")
+    assert cur.fetchall() == [("A",)]
 
     cur.execute("select attrs from structured")
     assert indent(cur.fetchall()) == [('{\n  "a": 1\n}',)]
 
-    cur.execute("select attrs['a'] from structured")
-    assert cur.fetchall() == [("1",)]
+    cur.execute("select attrs['a']::number from structured")
+    assert cur.fetchall() == [(1,)]
 
     cur.execute("create or replace table structured_nn (attrs object(a int not null) not null)")
     cur.execute("insert into structured_nn(attrs) select object_construct('a', 1)::object(a int not null)")
-    cur.execute("select attrs['a'] from structured_nn")
-    assert cur.fetchall() == [("1",)]
+    cur.execute("select attrs['a']::number from structured_nn")
+    assert cur.fetchall() == [(1,)]
 
 
 def test_semi_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -163,6 +163,11 @@ def test_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("select attrs['a'] from structured")
     assert cur.fetchall() == [("1",)]
 
+    cur.execute("create or replace table structured_nn (attrs object(a int not null) not null)")
+    cur.execute("insert into structured_nn(attrs) select object_construct('a', 1)")
+    cur.execute("select attrs['a'] from structured_nn")
+    assert cur.fetchall() == [("1",)]
+
 
 def test_semi_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("create or replace table semis (emails array, names object, notes variant)")

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -149,7 +149,10 @@ def test_to_variant(conn: snowflake.connector.SnowflakeConnection):
 
 def test_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("create or replace table structured (names array(varchar), attrs object(a int))")
-    cur.execute("insert into structured(names, attrs) select ['A', 'B'], object_construct('a', 1)")
+    cur.execute(
+        "insert into structured(names, attrs) "
+        "select ['A', 'B']::array(varchar), object_construct('a', 1)::object(a int)"
+    )
 
     cur.execute("select names from structured")
     assert indent(cur.fetchall()) == [('[\n  "A",\n  "B"\n]',)]
@@ -164,7 +167,7 @@ def test_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert cur.fetchall() == [("1",)]
 
     cur.execute("create or replace table structured_nn (attrs object(a int not null) not null)")
-    cur.execute("insert into structured_nn(attrs) select object_construct('a', 1)")
+    cur.execute("insert into structured_nn(attrs) select object_construct('a', 1)::object(a int not null)")
     cur.execute("select attrs['a'] from structured_nn")
     assert cur.fetchall() == [("1",)]
 

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -147,6 +147,23 @@ def test_to_variant(conn: snowflake.connector.SnowflakeConnection):
         assert json.loads(result[0]) == 42
 
 
+def test_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("create or replace table structured (names array(varchar), attrs object(a int))")
+    cur.execute("insert into structured(names, attrs) select ['A', 'B'], object_construct('a', 1)")
+
+    cur.execute("select names from structured")
+    assert indent(cur.fetchall()) == [('[\n  "A",\n  "B"\n]',)]
+
+    cur.execute("select names[0] from structured")
+    assert cur.fetchall() == [('"A"',)]
+
+    cur.execute("select attrs from structured")
+    assert indent(cur.fetchall()) == [('{\n  "a": 1\n}',)]
+
+    cur.execute("select attrs['a'] from structured")
+    assert cur.fetchall() == [("1",)]
+
+
 def test_semi_structured_types(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("create or replace table semis (emails array, names object, notes variant)")
     cur.execute(

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -722,6 +722,19 @@ def test_semi_structured_types_structured() -> None:
         == "CREATE TABLE table1 (name JSON NOT NULL)"
     )
 
+    assert (
+        sqlglot.parse_one("SELECT col::ARRAY(VARCHAR)", read="snowflake")
+        .transform(semi_structured_types)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(col AS JSON)"
+    )
+    assert (
+        sqlglot.parse_one("SELECT col::OBJECT(a INT)", read="snowflake")
+        .transform(semi_structured_types)
+        .sql(dialect="duckdb")
+        == "SELECT CAST(col AS JSON)"
+    )
+
 
 def test_show_tables_etc() -> None:
     def _show_tables_etc(e: Expr) -> Expr:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -701,6 +701,7 @@ def test_semi_structured_types_structured() -> None:
         "CREATE TABLE table1 (name ARRAY(ARRAY(INT)))",
         "CREATE TABLE table1 (name OBJECT(a INT))",
         "CREATE TABLE table1 (name OBJECT(a INT, b VARCHAR))",
+        "CREATE TABLE table1 (name OBJECT(a INT NOT NULL))",
     ]:
         assert (
             sqlglot.parse_one(sql, read="snowflake").transform(semi_structured_types).sql(dialect="duckdb")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -701,7 +701,6 @@ def test_semi_structured_types_structured() -> None:
         "CREATE TABLE table1 (name ARRAY(ARRAY(INT)))",
         "CREATE TABLE table1 (name OBJECT(a INT))",
         "CREATE TABLE table1 (name OBJECT(a INT, b VARCHAR))",
-        "CREATE TABLE table1 (name OBJECT(a INT NOT NULL))",
     ]:
         assert (
             sqlglot.parse_one(sql, read="snowflake").transform(semi_structured_types).sql(dialect="duckdb")

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -695,6 +695,27 @@ def test_semi_structured_types() -> None:
     )
 
 
+def test_semi_structured_types_structured() -> None:
+    for sql in [
+        "CREATE TABLE table1 (name ARRAY(VARCHAR))",
+        "CREATE TABLE table1 (name ARRAY(ARRAY(INT)))",
+        "CREATE TABLE table1 (name OBJECT(a INT))",
+        "CREATE TABLE table1 (name OBJECT(a INT, b VARCHAR))",
+    ]:
+        assert (
+            sqlglot.parse_one(sql, read="snowflake").transform(semi_structured_types).sql(dialect="duckdb")
+            == "CREATE TABLE table1 (name JSON)"
+        )
+
+    # structured types nested inside a type that isn't itself converted
+    assert (
+        sqlglot.parse_one("CREATE TABLE table1 (name MAP(VARCHAR, ARRAY(INT)))", read="snowflake")
+        .transform(semi_structured_types)
+        .sql(dialect="duckdb")
+        == "CREATE TABLE table1 (name MAP(TEXT, JSON))"
+    )
+
+
 def test_show_tables_etc() -> None:
     def _show_tables_etc(e: Expr) -> Expr:
         return show_tables_etc(e, None, None)

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -715,6 +715,13 @@ def test_semi_structured_types_structured() -> None:
         == "CREATE TABLE table1 (name MAP(TEXT, JSON))"
     )
 
+    assert (
+        sqlglot.parse_one("CREATE TABLE table1 (name OBJECT(a INT NOT NULL) NOT NULL)", read="snowflake")
+        .transform(semi_structured_types)
+        .sql(dialect="duckdb")
+        == "CREATE TABLE table1 (name JSON NOT NULL)"
+    )
+
 
 def test_show_tables_etc() -> None:
     def _show_tables_etc(e: Expr) -> Expr:


### PR DESCRIPTION
## Why

Closes #389   

Snowflake supports structured type declarations like `ARRAY(VARCHAR)` or `OBJECT(a INT)`. `fakesnow` converts these to `JSON` types, but retains the nested type information, causing DuckDB to emit `Parser Error: Expected a constant as type modifier`. 

## How

Convert Snowflake structured types to plain DuckDB `JSON` types while preserving their nullability constraints. This allows structured values to use the same JSON-backed representation as existing semi-structured types.

## Details 

`semi_structured_types()` copies the `DataType` node and reassigns only `this`, so a Snowflake structured type keeps its `expressions`:

There are are a few `arg_types` on a `DataType` node: 

```python
arg_types = {
    "this": True,        # required
    "expressions": False,
    "nested": False,
    "values": False,
    "kind": False,
    "nullable": False,
    "collate": False,
}
```

Returns a fresh `JSON` node instead, dropping the optional `arg_types` to prevent them from flowing through as type modifiers.

---

I found Snowflake's naming a bit confusing and wasn't sure if that needs disambiguation here: 

> [The Snowflake structured types are ARRAY, OBJECT, and MAP.](https://docs.snowflake.com/en/sql-reference/data-types-structured)

(from Snowflake docs)

 However, the types share names with semi-structured types, leading to weird test names like `test_semi_structured_types_structured()`, if that should be cleaned up, please let me know

## Testing

Added `test_semi_structured_types_structured`, covering `ARRAY(T)`, `OBJECT(k T)` and a structured type nested inside a `MAP`.