### PR TITLE
fix: match the DELETE in a MERGE regardless of case

### DIFF
--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -74,7 +74,7 @@ def _create_merge_candidates(merge_expr: exp.Merge) -> Expr:
             if isinstance(then, exp.Update):
                 case_when_clauses.append(f"WHEN {predicate} THEN {w_idx}")
                 values.update([str(c.expression) for c in then.expressions if isinstance(c.expression, exp.Column)])
-            elif isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 case_when_clauses.append(f"WHEN {predicate} THEN {w_idx}")
             else:
                 raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")
@@ -125,7 +125,7 @@ def _mutations(merge_expr: exp.Merge) -> list[Expr]:
         then = w.args.get("then")
 
         if matched:
-            if isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            if isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 delete_sql = f"""
                     DELETE FROM {target_tbl}
                     USING merge_candidates AS {source_tbl}
@@ -191,7 +191,7 @@ def _counts(merge_expr: exp.Merge) -> Expr:
         if matched:
             if isinstance(then, exp.Update):
                 operations["updated"].append(w_idx)
-            elif isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 operations["deleted"].append(w_idx)
             else:
                 raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -633,3 +633,17 @@ def test_merge_with_values_source(_fakesnow: None) -> None:
 
         cur.execute("select id, name from t order by id")
         assert cur.fetchall() == [(1, "updated"), (2, "inserted")]
+
+
+def test_merge_delete_lowercase(conn: snowflake.connector.SnowflakeConnection):
+    # sql is case insensitive, and sqlglot keeps the case of the DELETE token, so the whens
+    # can't be matched case sensitively
+    with conn.cursor() as cur:
+        cur.execute("create or replace table t (id int, v int)")
+        cur.execute("insert into t values (1, 10), (2, 20)")
+
+        cur.execute("merge into t using (select 1 as id) s on t.id = s.id when matched then delete")
+        assert cur.fetchall() == [(1,)]
+
+        cur.execute("select id from t order by id")
+        assert cur.fetchall() == [(2,)]


### PR DESCRIPTION
`merge into t using (...) s on t.id = s.id when matched then delete` fails with

```
AssertionError: Expected 'Update' or 'Delete', got delete
```

while the same statement in uppercase works. sqlglot keeps the case of the `DELETE` token, so the WHEN clause parses to `Var(this='delete')` or `Var(this='DELETE')` depending on how it was typed, and the three places that check it compared case sensitively.

Since it surfaces as a bare `AssertionError` the server turns it into a 500, which clients retry, so a lowercase merge delete looks like a transient failure rather than a rejected statement.

Found while adding `describeOnly` support for MERGE, but it's unrelated to that: this breaks ordinary execution too. The existing merge tests all spell it `THEN DELETE`, which is why it wasn't caught.

Verified all three case variants now work, and the delete-only merge returns `number of rows deleted`, matching what an account returns.
