### PR TITLE
fix: describe DDL and MERGE without running them

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -33,6 +33,7 @@ from fakesnow.copy_into import copy_into
 from fakesnow.params import MutableParams
 from fakesnow.rowtype import describe_as_result_metadata
 from fakesnow.transforms import stage
+from fakesnow.transforms.merge import operations as merge_operations
 
 if TYPE_CHECKING:
     # don't require pandas at import time
@@ -63,6 +64,11 @@ SQL_COPY_ROWS = Template(
     "NULL as first_error_column_name"
 )
 
+
+# Statements that report a status rather than a result set, so describing them without running
+# them is the same as describing the status. Verified against an account: CREATE, DROP, ALTER and
+# TRUNCATE all describe as a single "status" column.
+DDL_EXPRESSIONS = (exp.Create, exp.Drop, exp.Alter, exp.TruncateTable)
 
 # The result columns snowflake reports when asked to describe a DML statement without running it.
 # The counts are placeholders, only the column names and types are used.
@@ -158,6 +164,15 @@ class FakeSnowflakeCursor:
 
         if result_sql := DESCRIBE_RESULT_SQL.get(type(expression)):
             describe = result_sql
+        elif isinstance(expression, exp.Merge):
+            # a merge reports a count per operation it performs, so the columns depend on its
+            # WHEN clauses. the counts are placeholders, only the names and types are used.
+            counts = ", ".join(
+                f"0 as 'number of rows {op}'" for op, indices in merge_operations(expression).items() if indices
+            )
+            describe = f"SELECT {counts}"
+        elif isinstance(expression, DDL_EXPRESSIONS):
+            describe = SQL_SUCCESS
         elif isinstance(expression, exp.Select):
             # a describe request carries no bindings, so replace the placeholders with null to
             # make the statement runnable. it doesn't change the columns the query returns.

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -65,14 +65,13 @@ SQL_COPY_ROWS = Template(
 )
 
 
-# Statements that report a status rather than a result set, so describing them without running
-# them is the same as describing the status. Verified against an account: CREATE, DROP, ALTER and
-# TRUNCATE all describe as a single "status" column.
-DDL_EXPRESSIONS = (exp.Create, exp.Drop, exp.Alter, exp.TruncateTable)
-
-# The result columns snowflake reports when asked to describe a DML statement without running it.
+# The result columns snowflake reports when asked to describe a statement without running it.
 # The counts are placeholders, only the column names and types are used.
 DESCRIBE_RESULT_SQL: dict[type[Expr], str] = {
+    exp.Create: SQL_SUCCESS,
+    exp.Drop: SQL_SUCCESS,
+    exp.Alter: SQL_SUCCESS,
+    exp.TruncateTable: SQL_SUCCESS,
     exp.Insert: SQL_INSERTED_ROWS.substitute(count=0),
     exp.Update: SQL_UPDATED_ROWS.substitute(count=0),
     exp.Delete: SQL_DELETED_ROWS.substitute(count=0),
@@ -171,8 +170,6 @@ class FakeSnowflakeCursor:
                 f"0 as 'number of rows {op}'" for op, indices in merge_operations(expression).items() if indices
             )
             describe = f"SELECT {counts}"
-        elif isinstance(expression, DDL_EXPRESSIONS):
-            describe = SQL_SUCCESS
         elif isinstance(expression, exp.Select):
             # a describe request carries no bindings, so replace the placeholders with null to
             # make the statement runnable. it doesn't change the columns the query returns.

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -165,6 +165,36 @@ def _mutations(merge_expr: exp.Merge) -> list[Expr]:
     return statements
 
 
+def operations(merge_expr: exp.Merge) -> dict[str, list[int]]:
+    """The WHEN clause indices of a merge statement, by the operation they perform.
+
+    Only operations the statement performs have indices, eg: a merge that never deletes has an
+    empty list for "deleted". The order determines the order of the result columns, which is
+    what snowflake returns.
+    """
+
+    ops: dict[str, list[int]] = {"inserted": [], "updated": [], "deleted": []}
+
+    for w_idx, w in enumerate(merge_expr.args["whens"]):
+        assert isinstance(w, exp.When), f"Expected When expression, got {w}"
+
+        matched = w.args.get("matched")
+        then = w.args.get("then")
+
+        if matched:
+            if isinstance(then, exp.Update):
+                ops["updated"].append(w_idx)
+            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
+                ops["deleted"].append(w_idx)
+            else:
+                raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")
+        else:
+            assert isinstance(then, exp.Insert), f"Expected 'Insert', got {then}"
+            ops["inserted"].append(w_idx)
+
+    return ops
+
+
 def _counts(merge_expr: exp.Merge) -> Expr:
     """
     Given a merge statement, derive the a SQL statement which produces the following columns using the merge_candidates
@@ -178,30 +208,11 @@ def _counts(merge_expr: exp.Merge) -> Expr:
     column is not included.
     """
 
-    # Initialize dictionaries to store operation types and their corresponding indices
-    operations = {"inserted": [], "updated": [], "deleted": []}
-
-    # Iterate through the WHEN clauses to categorize operations
-    for w_idx, w in enumerate(merge_expr.args["whens"]):
-        assert isinstance(w, exp.When), f"Expected When expression, got {w}"
-
-        matched = w.args.get("matched")
-        then = w.args.get("then")
-
-        if matched:
-            if isinstance(then, exp.Update):
-                operations["updated"].append(w_idx)
-            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
-                operations["deleted"].append(w_idx)
-            else:
-                raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")
-        else:
-            assert isinstance(then, exp.Insert), f"Expected 'Insert', got {then}"
-            operations["inserted"].append(w_idx)
+    ops = operations(merge_expr)
 
     count_statements = [
         f"""COUNT_IF(merge_op in ({",".join(map(str, indices))})) as \"number of rows {op}\""""
-        for op, indices in operations.items()
+        for op, indices in ops.items()
         if indices
     ]
     sql = f"""

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -74,7 +74,7 @@ def _create_merge_candidates(merge_expr: exp.Merge) -> Expr:
             if isinstance(then, exp.Update):
                 case_when_clauses.append(f"WHEN {predicate} THEN {w_idx}")
                 values.update([str(c.expression) for c in then.expressions if isinstance(c.expression, exp.Column)])
-            elif isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 case_when_clauses.append(f"WHEN {predicate} THEN {w_idx}")
             else:
                 raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")
@@ -125,7 +125,7 @@ def _mutations(merge_expr: exp.Merge) -> list[Expr]:
         then = w.args.get("then")
 
         if matched:
-            if isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            if isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 delete_sql = f"""
                     DELETE FROM {target_tbl}
                     USING merge_candidates AS {source_tbl}
@@ -191,7 +191,7 @@ def _counts(merge_expr: exp.Merge) -> Expr:
         if matched:
             if isinstance(then, exp.Update):
                 operations["updated"].append(w_idx)
-            elif isinstance(then, exp.Var) and then.args.get("this") == "DELETE":
+            elif isinstance(then, exp.Var) and then.name.upper() == "DELETE":
                 operations["deleted"].append(w_idx)
             else:
                 raise AssertionError(f"Expected 'Update' or 'Delete', got {then}")

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -633,3 +633,17 @@ def test_merge_with_values_source(_fakesnow: None) -> None:
 
         cur.execute("select id, name from t order by id")
         assert cur.fetchall() == [(1, "updated"), (2, "inserted")]
+
+
+def test_merge_delete_lowercase(conn: snowflake.connector.SnowflakeConnection):
+    # sql is case insensitive, and sqlglot keeps the case of the DELETE token, so the whens
+    # can't be matched case sensitively
+    with conn.cursor() as cur:
+        cur.execute("create or replace table t (id int, v int)")
+        cur.execute("insert into t values (1, 10), (2, 20)")
+
+        cur.execute("merge into t using (select 1 as id) s on t.id = s.id when matched then delete")
+        assert cur.fetchall() == [(1,)]
+
+        cur.execute("select id from t order by id")
+        assert cur.fetchall() == [(2,)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -651,3 +651,41 @@ def test_server_describe_only(server: dict) -> None:
         # nothing ran
         cur.execute("select count(*) from example")
         assert cur.fetchall() == [(0,)]
+
+
+def test_server_describe_only_no_side_effects(server: dict) -> None:
+    # a describe request must not run the statement, so preparing a DDL or a MERGE can't
+    # create a table or move rows
+    with (
+        snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
+        conn.cursor() as cur,
+    ):
+        cur.execute("create or replace table example (id int, v int)")
+        cur.execute("insert into example values (1, 10)")
+
+        assert [m.name for m in cur.describe("create table side_effect (id int)")] == ["status"]
+        assert [m.name for m in cur.describe("drop table example")] == ["status"]
+        assert [m.name for m in cur.describe("alter table example add column w int")] == ["status"]
+        assert [m.name for m in cur.describe("truncate table example")] == ["status"]
+
+        merge = """
+            merge into example t using (select 1 as id, 2 as v) s on t.id = s.id
+            when matched then update set t.v = s.v
+            when not matched then insert values (s.id, s.v)
+            """
+        assert [m.name for m in cur.describe(merge)] == [
+            "number of rows inserted",
+            "number of rows updated",
+        ]
+        assert [
+            m.name
+            for m in cur.describe(
+                "merge into example t using (select 1 as id) s on t.id = s.id when matched then delete"
+            )
+        ] == ["number of rows deleted"]
+
+        # nothing ran: no new table, the columns and rows are untouched
+        cur.execute("select count(*) from information_schema.tables where table_name = 'SIDE_EFFECT'")
+        assert cur.fetchall() == [(0,)]
+        cur.execute("select id, v from example")
+        assert cur.fetchall() == [(1, 10)]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -636,6 +636,7 @@ def test_server_describe_only(server: dict) -> None:
         conn.cursor() as cur,
     ):
         cur.execute("create or replace table example (id int, name varchar)")
+        cur.execute("insert into example values (1, 'old')")
 
         assert [(m.name, m.type_code) for m in cur.describe("select id, name from example where id = ?")] == [
             ("ID", 0),
@@ -648,30 +649,10 @@ def test_server_describe_only(server: dict) -> None:
         ]
         assert [m.name for m in cur.describe("delete from example where id = ?")] == ["number of rows deleted"]
 
-        # nothing ran
-        cur.execute("select count(*) from example")
-        assert cur.fetchall() == [(0,)]
-
-
-def test_server_describe_only_no_side_effects(server: dict) -> None:
-    # a describe request must not run the statement, so preparing a DDL or a MERGE can't
-    # create a table or move rows
-    with (
-        snowflake.connector.connect(**server, database="db1", schema="schema1", paramstyle="qmark") as conn,
-        conn.cursor() as cur,
-    ):
-        cur.execute("create or replace table example (id int, v int)")
-        cur.execute("insert into example values (1, 10)")
-
-        assert [m.name for m in cur.describe("create table side_effect (id int)")] == ["status"]
-        assert [m.name for m in cur.describe("drop table example")] == ["status"]
-        assert [m.name for m in cur.describe("alter table example add column w int")] == ["status"]
-        assert [m.name for m in cur.describe("truncate table example")] == ["status"]
-
         merge = """
-            merge into example t using (select 1 as id, 2 as v) s on t.id = s.id
-            when matched then update set t.v = s.v
-            when not matched then insert values (s.id, s.v)
+            merge into example t using (select 1 as id, 'new' as name) s on t.id = s.id
+            when matched then update set t.name = s.name
+            when not matched then insert values (s.id, s.name)
             """
         assert [m.name for m in cur.describe(merge)] == [
             "number of rows inserted",
@@ -684,8 +665,14 @@ def test_server_describe_only_no_side_effects(server: dict) -> None:
             )
         ] == ["number of rows deleted"]
 
-        # nothing ran: no new table, the columns and rows are untouched
+        assert [m.name for m in cur.describe("create table side_effect (id int)")] == ["status"]
         cur.execute("select count(*) from information_schema.tables where table_name = 'SIDE_EFFECT'")
         assert cur.fetchall() == [(0,)]
-        cur.execute("select id, v from example")
-        assert cur.fetchall() == [(1, 10)]
+
+        assert [m.name for m in cur.describe("drop table example")] == ["status"]
+        assert [m.name for m in cur.describe("alter table example add column w int")] == ["status"]
+        assert [m.name for m in cur.describe("truncate table example")] == ["status"]
+
+        # nothing ran: the original table is untouched
+        cur.execute("select * from example")
+        assert cur.fetchall() == [(1, "old")]


### PR DESCRIPTION
### Why?

Preparing DDL or MERGE statements currently executes them, causing side effects before the caller requests execution. For example, describing a DROP can remove the table, while describing a MERGE can modify rows.

This differs from Snowflake, which returns result metadata without executing the statement.

### How?

Return Snowflake-compatible result metadata for DDL and MERGE statements without executing them.

### Details

`describeOnly` fell through to executing anything that wasn't a query or a plain INSERT/UPDATE/DELETE, so preparing a statement had side effects. The clearest way to see it is that the test I added fails on main like this:

```
assert [m.name for m in cur.describe("drop table example")] == ["status"]
>  assert [m.name for m in cur.describe("alter table example add column w int")] == ["status"]
E  ProgrammingError: 002003 (42S02): Catalog Error: Table with name EXAMPLE does not exist!
```

Describing the DROP dropped the table. Describing a MERGE moves rows the same way. `connection.prepareStatement(...)` is enough to trigger it, no execute needed.

An account doesn't run these. I checked with `cursor.describe` and then looked for the objects:

| statement | rowtype | created/changed anything |
| --- | --- | --- |
| CREATE TABLE | status | no |
| DROP TABLE | status | no |
| ALTER TABLE | status | no |
| CREATE VIEW | status | no |
| TRUNCATE | status | no |

So DDL is a single `status` column. MERGE reports a count per operation it actually performs, which the WHEN clauses already determine:

| merge | rowtype |
| --- | --- |
| matched update + not matched insert | number of rows inserted, number of rows updated |
| matched delete only | number of rows deleted |
| not matched insert only | number of rows inserted |

That's the same rule `_counts` uses to build the result, so I pulled its WHEN classification out into `operations()` and reused it rather than duplicating the logic.

SHOW still describes by running. It only reads, so there's no side effect, and its columns are built during execution. Happy to take that on separately if you want it.

Stacked on #391, which the delete-only merge case needs.

