### PR TITLE
feat: support * as an argument to OBJECT_CONSTRUCT

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -473,7 +473,8 @@ class FakeSnowflakeCursor:
                 self._duck_conn.execute(sql, params)
         except duckdb.BinderException as e:
             msg = e.args[0]
-            raise snowflake.connector.errors.ProgrammingError(msg=msg, errno=2043, sqlstate="02000") from e
+            errno, sqlstate = (100103, "22000") if "Duplicate struct entry name" in msg else (2043, "02000")
+            raise snowflake.connector.errors.ProgrammingError(msg=msg, errno=errno, sqlstate=sqlstate) from e
         except duckdb.CatalogException as e:
             # minimal processing to make it look like a snowflake exception, message content may differ
             msg = cast(str, e.args[0]).split("\n")[0]

--- a/fakesnow/macros.py
+++ b/fakesnow/macros.py
@@ -49,6 +49,21 @@ CREATE OR REPLACE MACRO ${catalog}._fs_object_construct(keys, vals, keep_nulls) 
 """
 )
 
+FS_OBJECT_CONSTRUCT_STAR = Template(
+    """
+CREATE OR REPLACE MACRO ${catalog}._fs_object_construct_star(row_value) AS (
+    SELECT COALESCE(json_group_object(key, value::JSON), '{}'::JSON)
+    FROM (
+        UNPIVOT (
+            SELECT TO_JSON(COLUMNS(*))
+            FROM (SELECT UNNEST(row_value))
+        ) ON COLUMNS(*)::VARCHAR
+        INTO NAME key VALUE value
+    )
+);
+"""
+)
+
 FS_TO_TIMESTAMP = Template(
     """
 CREATE OR REPLACE MACRO ${catalog}._fs_to_timestamp(val, scale) AS (
@@ -86,5 +101,6 @@ def creation_sql(catalog: str) -> str:
         {FS_FLATTEN.substitute(catalog=catalog)};
         {FS_HAVERSINE.substitute(catalog=catalog)};
         {FS_OBJECT_CONSTRUCT.substitute(catalog=catalog)};
+        {FS_OBJECT_CONSTRUCT_STAR.substitute(catalog=catalog)};
         {FS_TO_TIMESTAMP.substitute(catalog=catalog)};
     """

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -874,16 +874,10 @@ def _star_object(star: Expr, *, keep_nulls: bool) -> Expr:
         # spread into STRUCT_PACK args so the column names don't need to be known here
         source = exp.Anonymous(this="STRUCT_PACK", expressions=[exp.var("*COLUMNS(*)")])
 
-    obj = exp.Anonymous(this="TO_JSON", expressions=[source])
     if keep_nulls:
-        return obj
+        return exp.Anonymous(this="TO_JSON", expressions=[source])
 
-    # OBJECT_CONSTRUCT omits nulls whereas TO_JSON keeps them. A JSON merge patch removes
-    # members whose value in the patch is null (RFC 7396), dropping exactly those.
-    return exp.Anonymous(
-        this="JSON_MERGE_PATCH",
-        expressions=[exp.Literal(this="{}", is_string=True), obj],
-    )
+    return exp.Anonymous(this="_FS_OBJECT_CONSTRUCT_STAR", expressions=[source])
 
 
 def object_construct(expression: Expr) -> Expr:

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -845,12 +845,62 @@ def sample(expression: Expr) -> Expr:
     return expression
 
 
+# A star can carry a column filter, eg: * ILIKE 'col1%', which isn't supported yet.
+_STAR_FILTERS = ("ilike", "except_", "replace", "rename")
+
+
+def _star_arg(expression: Expr) -> Expr | None:
+    """Return the star argument of OBJECT_CONSTRUCT, if it's one that can be transformed."""
+
+    if not expression.is_star:
+        return None
+
+    star = expression.this if isinstance(expression, exp.Column) else expression
+    if any(star.args.get(name) for name in _STAR_FILTERS):
+        return None
+
+    return expression
+
+
+def _star_object(star: Expr, *, keep_nulls: bool) -> Expr:
+    """Build an object containing every column the star refers to."""
+
+    table = star.args.get("table") if isinstance(star, exp.Column) else None
+    if table is not None:
+        # a qualified star, eg: t.*, names a single source which TO_JSON accepts directly
+        source = exp.Column(this=table.copy())
+    else:
+        # an unqualified star is every column in scope, ie: whatever COLUMNS(*) expands to,
+        # spread into STRUCT_PACK args so the column names don't need to be known here
+        source = exp.Anonymous(this="STRUCT_PACK", expressions=[exp.var("*COLUMNS(*)")])
+
+    obj = exp.Anonymous(this="TO_JSON", expressions=[source])
+    if keep_nulls:
+        return obj
+
+    # OBJECT_CONSTRUCT omits nulls whereas TO_JSON keeps them. A JSON merge patch removes
+    # members whose value in the patch is null (RFC 7396), dropping exactly those.
+    return exp.Anonymous(
+        this="JSON_MERGE_PATCH",
+        expressions=[exp.Literal(this="{}", is_string=True), obj],
+    )
+
+
 def object_construct(expression: Expr) -> Expr:
-    """Convert OBJECT_CONSTRUCT/OBJECT_CONSTRUCT_KEEP_NULL to _FS_OBJECT_CONSTRUCT."""
+    """Convert OBJECT_CONSTRUCT/OBJECT_CONSTRUCT_KEEP_NULL to _FS_OBJECT_CONSTRUCT.
+
+    A star argument, eg: OBJECT_CONSTRUCT(*), becomes TO_JSON instead, because
+    _FS_OBJECT_CONSTRUCT needs the keys and values which a star doesn't provide.
+    """
 
     items: list[tuple[Expr, Expr]] = []
 
-    if isinstance(expression, exp.Struct):
+    if isinstance(expression, exp.StarMap):
+        # OBJECT_CONSTRUCT(*) or OBJECT_CONSTRUCT(t.*)
+        star = _star_arg(expression.this)
+        return _star_object(star, keep_nulls=False) if star else expression
+
+    elif isinstance(expression, exp.Struct):
         # OBJECT_CONSTRUCT
         keep_nulls = False
 
@@ -861,6 +911,10 @@ def object_construct(expression: Expr) -> Expr:
     elif isinstance(expression, exp.JSONObject):
         # OBJECT_CONSTRUCT_KEEP_NULL
         keep_nulls = True
+
+        # OBJECT_CONSTRUCT_KEEP_NULL(*) is a single star rather than key/value pairs
+        if len(expression.expressions) == 1 and (star := _star_arg(expression.expressions[0])):
+            return _star_object(star, keep_nulls=True)
 
         for kv in expression.expressions:
             assert isinstance(kv, exp.JSONKeyValue)

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -151,9 +151,7 @@ def test_object_construct_star(cur: snowflake.connector.cursor.SnowflakeCursor):
 
 def test_object_construct_star_preserves_json_nulls(cur: snowflake.connector.cursor.SnowflakeCursor):
     cur.execute("create or replace table tbl (id int, sql_null variant, json_null variant, nested variant)")
-    cur.execute(
-        "insert into tbl select 1, null, parse_json('null'), parse_json('{\"x\":null,\"y\":1}')"
-    )
+    cur.execute("insert into tbl select 1, null, parse_json('null'), parse_json('{\"x\":null,\"y\":1}')")
 
     cur.execute("select object_construct(*) from tbl")
     assert indent(cur.fetchall()) == [

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -167,9 +167,10 @@ def test_object_construct_star_duplicate_key(cur: snowflake.connector.cursor.Sno
     cur.execute("create or replace table other (a int, c varchar)")
     cur.execute("insert into other values (1, 'y')")
 
-    # snowflake rejects this too, with: Duplicate field key 'A'
-    with pytest.raises(snowflake.connector.errors.ProgrammingError, match="Duplicate struct entry name"):
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as exc:
         cur.execute("select object_construct(*) from tbl as t join other as o on t.a = o.a")
+
+    assert (exc.value.errno, exc.value.sqlstate) == (100103, "22000")
 
 
 def test_to_variant(conn: snowflake.connector.SnowflakeConnection):

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 
+import pytest
 import snowflake.connector
 import snowflake.connector.cursor
 
@@ -125,6 +126,50 @@ def test_object_construct(conn: snowflake.connector.SnowflakeConnection):
         result = cur.fetchone()
         assert isinstance(result, tuple)
         assert json.loads(result[1]) == json.loads('{\n  "k1": "v1",\n  "k2": "v2",\n  "k3": "v3"\n}')
+
+
+def test_object_construct_star(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("create or replace table tbl (a int, b varchar)")
+    cur.execute("insert into tbl values (1, 'x'), (2, null)")
+
+    # keys are the column names, uppercased as unquoted identifiers
+    cur.execute("select object_construct(*) from tbl")
+    assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2\n}',)]
+
+    cur.execute("select object_construct_keep_null(*) from tbl")
+    assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2,\n  "B": null\n}',)]
+
+    cur.execute("select object_construct(t.*) from tbl as t")
+    assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2\n}',)]
+
+    # a qualified star only includes the columns of the source it names
+    cur.execute("create or replace table other (a int, c varchar)")
+    cur.execute("insert into other values (1, 'y'), (2, null)")
+    cur.execute("select object_construct(t.*) from tbl as t join other as o on t.a = o.a")
+    assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2\n}',)]
+
+
+@pytest.mark.xfail(
+    reason="sqlglot can't parse a qualified star in OBJECT_CONSTRUCT_KEEP_NULL, "
+    "see https://github.com/tobymao/sqlglot/issues/8262",
+)
+def test_object_construct_keep_null_qualified_star(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("create or replace table tbl (a int, b varchar)")
+    cur.execute("insert into tbl values (1, 'x'), (2, null)")
+
+    cur.execute("select object_construct_keep_null(t.*) from tbl as t")
+    assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2,\n  "B": null\n}',)]
+
+
+def test_object_construct_star_duplicate_key(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("create or replace table tbl (a int, b varchar)")
+    cur.execute("insert into tbl values (1, 'x')")
+    cur.execute("create or replace table other (a int, c varchar)")
+    cur.execute("insert into other values (1, 'y')")
+
+    # snowflake rejects this too, with: Duplicate field key 'A'
+    with pytest.raises(snowflake.connector.errors.ProgrammingError, match="Duplicate struct entry name"):
+        cur.execute("select object_construct(*) from tbl as t join other as o on t.a = o.a")
 
 
 def test_to_variant(conn: snowflake.connector.SnowflakeConnection):

--- a/tests/test_semis.py
+++ b/tests/test_semis.py
@@ -149,6 +149,18 @@ def test_object_construct_star(cur: snowflake.connector.cursor.SnowflakeCursor):
     assert indent(cur.fetchall()) == [('{\n  "A": 1,\n  "B": "x"\n}',), ('{\n  "A": 2\n}',)]
 
 
+def test_object_construct_star_preserves_json_nulls(cur: snowflake.connector.cursor.SnowflakeCursor):
+    cur.execute("create or replace table tbl (id int, sql_null variant, json_null variant, nested variant)")
+    cur.execute(
+        "insert into tbl select 1, null, parse_json('null'), parse_json('{\"x\":null,\"y\":1}')"
+    )
+
+    cur.execute("select object_construct(*) from tbl")
+    assert indent(cur.fetchall()) == [
+        ('{\n  "ID": 1,\n  "JSON_NULL": null,\n  "NESTED": {\n    "x": null,\n    "y": 1\n  }\n}',)
+    ]
+
+
 @pytest.mark.xfail(
     reason="sqlglot can't parse a qualified star in OBJECT_CONSTRUCT_KEEP_NULL, "
     "see https://github.com/tobymao/sqlglot/issues/8262",

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -639,6 +639,38 @@ def test_object_construct() -> None:
     )
 
 
+def test_object_construct_star() -> None:
+    assert (
+        sqlglot.parse_one("SELECT OBJECT_CONSTRUCT(*) FROM tbl", read="snowflake")
+        .transform(object_construct)
+        .sql(dialect="duckdb")
+        == "SELECT JSON_MERGE_PATCH('{}', TO_JSON(STRUCT_PACK(*COLUMNS(*)))) FROM tbl"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT OBJECT_CONSTRUCT_KEEP_NULL(*) FROM tbl", read="snowflake")
+        .transform(object_construct)
+        .sql(dialect="duckdb")
+        == "SELECT TO_JSON(STRUCT_PACK(*COLUMNS(*))) FROM tbl"
+    )
+
+    assert (
+        sqlglot.parse_one("SELECT OBJECT_CONSTRUCT(t.*) FROM tbl AS t", read="snowflake")
+        .transform(object_construct)
+        .sql(dialect="duckdb")
+        == "SELECT JSON_MERGE_PATCH('{}', TO_JSON(t)) FROM tbl AS t"
+    )
+
+    # a filtered star selects a subset of the columns, which isn't supported yet, so it's
+    # left alone rather than transformed into every column
+    assert (
+        sqlglot.parse_one("SELECT OBJECT_CONSTRUCT(* ILIKE 'a%') FROM tbl", read="snowflake")
+        .transform(object_construct)
+        .sql(dialect="snowflake")
+        == "SELECT OBJECT_CONSTRUCT(* ILIKE 'a%') FROM tbl"
+    )
+
+
 def test_random() -> None:
     e = sqlglot.parse_one("select random(420)").transform(random)
 

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -644,7 +644,7 @@ def test_object_construct_star() -> None:
         sqlglot.parse_one("SELECT OBJECT_CONSTRUCT(*) FROM tbl", read="snowflake")
         .transform(object_construct)
         .sql(dialect="duckdb")
-        == "SELECT JSON_MERGE_PATCH('{}', TO_JSON(STRUCT_PACK(*COLUMNS(*)))) FROM tbl"
+        == "SELECT _FS_OBJECT_CONSTRUCT_STAR(STRUCT_PACK(*COLUMNS(*))) FROM tbl"
     )
 
     assert (
@@ -658,7 +658,7 @@ def test_object_construct_star() -> None:
         sqlglot.parse_one("SELECT OBJECT_CONSTRUCT(t.*) FROM tbl AS t", read="snowflake")
         .transform(object_construct)
         .sql(dialect="duckdb")
-        == "SELECT JSON_MERGE_PATCH('{}', TO_JSON(t)) FROM tbl AS t"
+        == "SELECT _FS_OBJECT_CONSTRUCT_STAR(t) FROM tbl AS t"
     )
 
     # a filtered star selects a subset of the columns, which isn't supported yet, so it's


### PR DESCRIPTION
### Why?

Snowflake supports wildcard arguments for `OBJECT_CONSTRUCT` and related functions, but these queries currently fail in Fakesnow. This prevents Snowflake-compatible queries that construct objects from complete rows from running locally.

Fixes #394

### How?

Treat wildcard inputs as row values. For `OBJECT_CONSTRUCT`, a DuckDB macro serializes columns before unpivoting so SQL `NULL` values are omitted while explicit and nested JSON `null` values are preserved; `OBJECT_CONSTRUCT_KEEP_NULL` uses row serialization directly.
