### PR TITLE
feat: support timestamp and time dtypes in write_pandas auto_create_table under use_logical_type

### DIFF
--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -36,7 +36,7 @@ WritePandasResult = tuple[
 ]
 
 
-def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype) -> str:
+def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_type: bool = False) -> str:
     import pandas as pd
 
     if pd.api.types.is_bool_dtype(dtype):
@@ -51,7 +51,12 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype) -> str:
         return "VARCHAR"
     elif isinstance(dtype, pd.CategoricalDtype):
         # parquet stages a category as a dictionary of its own type, which is what snowflake infers
-        return sql_type(dtype.categories.dtype)
+        return sql_type(dtype.categories.dtype, use_logical_type=use_logical_type)
+    elif use_logical_type and pd.api.types.is_datetime64_any_dtype(dtype):
+        # without USE_LOGICAL_TYPE snowflake infers a number from the epoch offset the staged
+        # parquet column holds, except for a tz-aware sub-nanosecond one, see
+        # https://docs.snowflake.com/en/sql-reference/sql/create-file-format#label-parquet-format-type-options
+        return "TIMESTAMP_LTZ" if isinstance(dtype, pd.DatetimeTZDtype) else "TIMESTAMP_NTZ"
     else:
         raise NotImplementedError(f"sql_type {dtype=}")
 
@@ -71,6 +76,7 @@ def write_pandas(
     create_temp_table: bool = False,
     overwrite: bool = False,
     table_type: Literal["", "temp", "temporary", "transient"] = "",
+    use_logical_type: bool | None = None,
     **kwargs: Any,
 ) -> WritePandasResult:
     name = table_name
@@ -80,7 +86,7 @@ def write_pandas(
         name = f"{database}.{name}"
 
     if auto_create_table:
-        cols = [f"{c} {sql_type(t)}" for c, t in df.dtypes.to_dict().items()]
+        cols = [f"{c} {sql_type(t, use_logical_type=bool(use_logical_type))}" for c, t in df.dtypes.to_dict().items()]
 
         if overwrite:
             # overwrite drops and recreates the table, so its schema matches the dataframe

--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -57,8 +57,18 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_
         # parquet column holds, except for a tz-aware sub-nanosecond one, see
         # https://docs.snowflake.com/en/sql-reference/sql/create-file-format#label-parquet-format-type-options
         return "TIMESTAMP_LTZ" if isinstance(dtype, pd.DatetimeTZDtype) else "TIMESTAMP_NTZ"
+    elif use_logical_type and _is_time(dtype):
+        return "TIME"
     else:
         raise NotImplementedError(f"sql_type {dtype=}")
+
+
+def _is_time(dtype: np.dtype | pd.api.extensions.ExtensionDtype) -> bool:
+    # pandas has no time dtype of its own, only an arrow-backed one
+    import pandas as pd
+    import pyarrow as pa
+
+    return isinstance(dtype, pd.ArrowDtype) and pa.types.is_time(dtype.pyarrow_dtype)
 
 
 def write_pandas(

--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -44,10 +44,9 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_
     elif pd.api.types.is_integer_dtype(dtype):
         return "NUMBER"
     elif str(dtype) == "float16":
-        if use_logical_type:
-            # snowflake's infer_schema returns no columns for a staged half float under USE_LOGICAL_TYPE
-            raise NotImplementedError(f"sql_type {dtype=} {use_logical_type=}")
-        return "BINARY"
+        # snowflake's infer_schema returns no columns for a staged half float under USE_LOGICAL_TYPE
+        if not use_logical_type:
+            return "BINARY"
     elif pd.api.types.is_float_dtype(dtype):
         return "FLOAT"
     elif pd.api.types.is_string_dtype(dtype):
@@ -60,8 +59,8 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_
         return "TIMESTAMP_LTZ" if isinstance(dtype, pd.DatetimeTZDtype) else "TIMESTAMP_NTZ"
     elif use_logical_type and _is_time(dtype):
         return "TIME"
-    else:
-        raise NotImplementedError(f"sql_type {dtype=}")
+
+    raise NotImplementedError(f"sql_type {dtype=} {use_logical_type=}")
 
 
 def _is_time(dtype: np.dtype | pd.api.extensions.ExtensionDtype) -> bool:

--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -96,6 +96,11 @@ def write_pandas(
         name = f"{database}.{name}"
 
     if auto_create_table:
+        if use_logical_type and any(str(t) == "float16" for t in df.dtypes):
+            # snowflake's infer_schema returns no columns at all for a staged half float under
+            # USE_LOGICAL_TYPE = TRUE, so the connector fails looking up the first column's type
+            raise KeyError(df.columns[0])
+
         cols = [f"{c} {sql_type(t, use_logical_type=bool(use_logical_type))}" for c, t in df.dtypes.to_dict().items()]
 
         if overwrite:

--- a/fakesnow/pandas_tools.py
+++ b/fakesnow/pandas_tools.py
@@ -44,6 +44,9 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_
     elif pd.api.types.is_integer_dtype(dtype):
         return "NUMBER"
     elif str(dtype) == "float16":
+        if use_logical_type:
+            # snowflake's infer_schema returns no columns for a staged half float under USE_LOGICAL_TYPE
+            raise NotImplementedError(f"sql_type {dtype=} {use_logical_type=}")
         return "BINARY"
     elif pd.api.types.is_float_dtype(dtype):
         return "FLOAT"
@@ -53,8 +56,6 @@ def sql_type(dtype: np.dtype | pd.api.extensions.ExtensionDtype, *, use_logical_
         # parquet stages a category as a dictionary of its own type, which is what snowflake infers
         return sql_type(dtype.categories.dtype, use_logical_type=use_logical_type)
     elif use_logical_type and pd.api.types.is_datetime64_any_dtype(dtype):
-        # without USE_LOGICAL_TYPE snowflake infers a number from the epoch offset the staged
-        # parquet column holds, except for a tz-aware sub-nanosecond one, see
         # https://docs.snowflake.com/en/sql-reference/sql/create-file-format#label-parquet-format-type-options
         return "TIMESTAMP_LTZ" if isinstance(dtype, pd.DatetimeTZDtype) else "TIMESTAMP_NTZ"
     elif use_logical_type and _is_time(dtype):
@@ -96,11 +97,6 @@ def write_pandas(
         name = f"{database}.{name}"
 
     if auto_create_table:
-        if use_logical_type and any(str(t) == "float16" for t in df.dtypes):
-            # snowflake's infer_schema returns no columns at all for a staged half float under
-            # USE_LOGICAL_TYPE = TRUE, so the connector fails looking up the first column's type
-            raise KeyError(df.columns[0])
-
         cols = [f"{c} {sql_type(t, use_logical_type=bool(use_logical_type))}" for c, t in df.dtypes.to_dict().items()]
 
         if overwrite:

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -4,6 +4,7 @@ import datetime
 import json
 
 import pandas as pd
+import pyarrow as pa
 import pytest
 import pytz
 import snowflake.connector
@@ -129,6 +130,26 @@ def test_write_pandas_auto_create_timestamp_tz_described_as_ltz(conn: snowflake.
 
         cur.execute("describe table example")
         assert [(r[0], r[1]) for r in cur.fetchall()] == [("TZ", "TIMESTAMP_LTZ(9)")]
+
+
+def test_write_pandas_auto_create_time(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        at = datetime.time(12, 0)
+        df = pd.DataFrame(
+            {
+                "US": pd.Series([at], dtype=pd.ArrowDtype(pa.time64("us"))),
+                "NS": pd.Series([at], dtype=pd.ArrowDtype(pa.time64("ns"))),
+            }
+        )
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+        cur.execute("describe table example")
+        assert [(r[0], r[1]) for r in cur.fetchall()] == [("US", "TIME(9)"), ("NS", "TIME(9)")]
+
+        cur.execute("select * from example")
+        assert cur.fetchall() == [(at, at)]
 
 
 def test_write_pandas_auto_create_timestamps_without_use_logical_type(

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -170,6 +170,26 @@ def test_write_pandas_auto_create_time(conn: snowflake.connector.SnowflakeConnec
         assert cur.fetchall() == [(at, at)]
 
 
+def test_write_pandas_auto_create_category_of_timestamps(conn: snowflake.connector.SnowflakeConnection):
+    # parquet stages a category as its category dtype, so USE_LOGICAL_TYPE decides this column too
+    with conn.cursor() as cur:
+        df = pd.DataFrame(
+            {"TS": pd.Series([pd.Timestamp("2025-01-01 12:00")], dtype="datetime64[us]").astype("category")}
+        )
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+        cur.execute("describe table example")
+        assert [(r[0], r[1]) for r in cur.fetchall()] == [("TS", "TIMESTAMP_NTZ(9)")]
+
+        cur.execute("select * from example")
+        assert cur.fetchall() == [(datetime.datetime(2025, 1, 1, 12, 0),)]
+
+        with pytest.raises(NotImplementedError, match="sql_type dtype="):
+            snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE2", auto_create_table=True)
+
+
 def test_write_pandas_auto_create_timestamps_without_use_logical_type(
     conn: snowflake.connector.SnowflakeConnection,
 ):

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -80,6 +80,67 @@ def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection
         assert cur.fetchall() == [(b"\x00>",), (None,)]
 
 
+def test_write_pandas_auto_create_timestamps(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        at = pd.Timestamp("2025-01-01 12:00")
+        df = pd.DataFrame(
+            {
+                # the precision of the staged column doesn't change what snowflake reads
+                "NS": pd.Series([at]).astype("datetime64[ns]"),
+                "US": pd.Series([at]).astype("datetime64[us]"),
+                "S": pd.Series([at]).astype("datetime64[s]"),
+            }
+        )
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+        cur.execute("describe table example")
+        assert [(r[0], r[1]) for r in cur.fetchall()] == [
+            ("NS", "TIMESTAMP_NTZ(9)"),
+            ("US", "TIMESTAMP_NTZ(9)"),
+            ("S", "TIMESTAMP_NTZ(9)"),
+        ]
+
+        cur.execute("select * from example")
+        naive = datetime.datetime(2025, 1, 1, 12, 0)
+        assert cur.fetchall() == [(naive, naive, naive)]
+
+
+def test_write_pandas_auto_create_timestamp_tz(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        at = pd.Timestamp("2025-01-01 12:00", tz="UTC")
+        df = pd.DataFrame({"TZ": pd.Series([at]).astype("datetime64[us, UTC]")})
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+        cur.execute("select tz from example")
+        assert cur.fetchall() == [(datetime.datetime(2025, 1, 1, 12, 0, tzinfo=pytz.utc),)]
+
+
+@pytest.mark.xfail(reason="a timestamp_ltz column is described as timestamp_tz")
+def test_write_pandas_auto_create_timestamp_tz_described_as_ltz(conn: snowflake.connector.SnowflakeConnection):
+    with conn.cursor() as cur:
+        df = pd.DataFrame({"TZ": pd.Series([pd.Timestamp("2025-01-01 12:00", tz="UTC")])})
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+        cur.execute("describe table example")
+        assert [(r[0], r[1]) for r in cur.fetchall()] == [("TZ", "TIMESTAMP_LTZ(9)")]
+
+
+def test_write_pandas_auto_create_timestamps_without_use_logical_type(
+    conn: snowflake.connector.SnowflakeConnection,
+):
+    # without it snowflake infers a number, whose unit follows the dtype, rather than a timestamp
+    df = pd.DataFrame({"TS": pd.Series([pd.Timestamp("2025-01-01 12:00")])})
+
+    with pytest.raises(NotImplementedError, match="sql_type dtype="):
+        snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE", auto_create_table=True)
+
+
 def test_write_pandas_auto_create_unsupported_dtype(conn: snowflake.connector.SnowflakeConnection):
     df = pd.DataFrame({"C": pd.Series([pd.Period("2025-01", freq="M")])})
 

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -32,14 +32,15 @@ def test_write_pandas_auto_create(conn: snowflake.connector.SnowflakeConnection)
 @pytest.mark.parametrize("use_logical_type", [None, False, True])
 def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConnection, use_logical_type: bool | None):
     # USE_LOGICAL_TYPE only changes how a staged time or timestamp is read, so these are the same
-    # column under either setting
+    # column under either setting. float16 is excluded because it isn't: snowflake's infer_schema
+    # returns no columns at all for a staged half float under USE_LOGICAL_TYPE = TRUE, so the
+    # connector fails with a KeyError, see test_write_pandas_float16_null.
     with conn.cursor() as cur:
         df = pd.DataFrame(
             {
                 "INT32": pd.Series([1], dtype="int32"),
                 "NULLABLE_INT64": pd.Series([1], dtype="Int64"),
                 "UINT8": pd.Series([1], dtype="uint8"),
-                "FLOAT16": pd.Series([1.5], dtype="float16"),
                 "FLOAT32": pd.Series([1.5], dtype="float32"),
                 "FLOAT64": pd.Series([1.5], dtype="float64"),
                 "BOOL": pd.Series([True], dtype="bool"),
@@ -61,7 +62,6 @@ def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConn
             ("INT32", "NUMBER(38,0)"),
             ("NULLABLE_INT64", "NUMBER(38,0)"),
             ("UINT8", "NUMBER(38,0)"),
-            ("FLOAT16", "BINARY(8388608)"),
             ("FLOAT32", "FLOAT"),
             ("FLOAT64", "FLOAT"),
             ("BOOL", "BOOLEAN"),
@@ -74,14 +74,18 @@ def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConn
         ]
 
         cur.execute("select * from example")
-        assert cur.fetchall() == [(1, 1, 1, b"\x00>", 1.5, 1.5, True, True, "a", 1, 1.5, "a", "a")]
+        assert cur.fetchall() == [(1, 1, 1, 1.5, 1.5, True, True, "a", 1, 1.5, "a", "a")]
 
 
 def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection):
     df = pd.DataFrame({"C": pd.Series([1.5, None], dtype="float16")})
+    # snowflake can only auto_create_table this column without USE_LOGICAL_TYPE = TRUE
     snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE", auto_create_table=True)
 
     with conn.cursor() as cur:
+        cur.execute("describe table example")
+        assert [(r[0], r[1]) for r in cur.fetchall()] == [("C", "BINARY(8388608)")]
+
         cur.execute("select * from example")
         assert cur.fetchall() == [(b"\x00>",), (None,)]
 

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -32,9 +32,8 @@ def test_write_pandas_auto_create(conn: snowflake.connector.SnowflakeConnection)
 @pytest.mark.parametrize("use_logical_type", [None, False, True])
 def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConnection, use_logical_type: bool | None):
     # USE_LOGICAL_TYPE only changes how a staged time or timestamp is read, so these are the same
-    # column under either setting. float16 is excluded because it isn't: snowflake's infer_schema
-    # returns no columns at all for a staged half float under USE_LOGICAL_TYPE = TRUE, so the
-    # connector fails with a KeyError, see test_write_pandas_float16_null.
+    # column under either setting. float16 is excluded because it can't be created under
+    # USE_LOGICAL_TYPE = TRUE at all, see test_write_pandas_float16_use_logical_type.
     with conn.cursor() as cur:
         df = pd.DataFrame(
             {
@@ -79,7 +78,6 @@ def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConn
 
 def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection):
     df = pd.DataFrame({"C": pd.Series([1.5, None], dtype="float16")})
-    # snowflake can only auto_create_table this column without USE_LOGICAL_TYPE = TRUE
     snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE", auto_create_table=True)
 
     with conn.cursor() as cur:
@@ -88,6 +86,20 @@ def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection
 
         cur.execute("select * from example")
         assert cur.fetchall() == [(b"\x00>",), (None,)]
+
+
+@pytest.mark.parametrize("columns", [["HALF"], ["HALF", "OTHER"], ["OTHER", "HALF"]])
+def test_write_pandas_float16_use_logical_type(conn: snowflake.connector.SnowflakeConnection, columns: list[str]):
+    # infer_schema returns no columns for a staged half float under USE_LOGICAL_TYPE = TRUE, so
+    # snowflake's own write_pandas raises a KeyError naming the first column, whichever it is
+    df = pd.DataFrame({c: pd.Series([1.5], dtype="float16" if c == "HALF" else "float32") for c in columns})
+
+    with pytest.raises(KeyError) as excinfo:
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
+        )
+
+    assert excinfo.value.args == (columns[0],)
 
 
 def test_write_pandas_auto_create_timestamps(conn: snowflake.connector.SnowflakeConnection):

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -85,17 +85,6 @@ def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection
         assert cur.fetchall() == [(b"\x00>",), (None,)]
 
 
-def test_write_pandas_float16_use_logical_type(conn: snowflake.connector.SnowflakeConnection):
-    # snowflake's infer_schema returns no columns for a staged half float under
-    # USE_LOGICAL_TYPE = TRUE, so it can't create the table either
-    df = pd.DataFrame({"C": pd.Series([1.5], dtype="float16")})
-
-    with pytest.raises(NotImplementedError, match=r"sql_type dtype=dtype\('float16'\) use_logical_type=True"):
-        snowflake.connector.pandas_tools.write_pandas(
-            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
-        )
-
-
 def test_write_pandas_auto_create_timestamps(conn: snowflake.connector.SnowflakeConnection):
     with conn.cursor() as cur:
         at = pd.Timestamp("2025-01-01 12:00")
@@ -182,19 +171,6 @@ def test_write_pandas_auto_create_category_of_timestamps(conn: snowflake.connect
 
         cur.execute("select * from example")
         assert cur.fetchall() == [(datetime.datetime(2025, 1, 1, 12, 0),)]
-
-        with pytest.raises(NotImplementedError, match="sql_type dtype="):
-            snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE2", auto_create_table=True)
-
-
-def test_write_pandas_auto_create_timestamps_without_use_logical_type(
-    conn: snowflake.connector.SnowflakeConnection,
-):
-    # without it snowflake infers a number, whose unit follows the dtype, rather than a timestamp
-    df = pd.DataFrame({"TS": pd.Series([pd.Timestamp("2025-01-01 12:00")])})
-
-    with pytest.raises(NotImplementedError, match="sql_type dtype="):
-        snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE", auto_create_table=True)
 
 
 def test_write_pandas_auto_create_unsupported_dtype(conn: snowflake.connector.SnowflakeConnection):

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -31,9 +31,6 @@ def test_write_pandas_auto_create(conn: snowflake.connector.SnowflakeConnection)
 
 @pytest.mark.parametrize("use_logical_type", [None, False, True])
 def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConnection, use_logical_type: bool | None):
-    # USE_LOGICAL_TYPE only changes how a staged time or timestamp is read, so these are the same
-    # column under either setting. float16 is excluded because it can't be created under
-    # USE_LOGICAL_TYPE = TRUE at all, see test_write_pandas_float16_use_logical_type.
     with conn.cursor() as cur:
         df = pd.DataFrame(
             {

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -29,7 +29,10 @@ def test_write_pandas_auto_create(conn: snowflake.connector.SnowflakeConnection)
         assert cur.fetchall() == [(1, "Jenny"), (2, "Jasper")]
 
 
-def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConnection):
+@pytest.mark.parametrize("use_logical_type", [None, False, True])
+def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConnection, use_logical_type: bool | None):
+    # USE_LOGICAL_TYPE only changes how a staged time or timestamp is read, so these are the same
+    # column under either setting
     with conn.cursor() as cur:
         df = pd.DataFrame(
             {
@@ -48,7 +51,9 @@ def test_write_pandas_auto_create_dtypes(conn: snowflake.connector.SnowflakeConn
                 "OBJECT": pd.Series(["a"], dtype="object"),
             }
         )
-        snowflake.connector.pandas_tools.write_pandas(conn, df, "EXAMPLE", auto_create_table=True)
+        snowflake.connector.pandas_tools.write_pandas(
+            conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=use_logical_type
+        )
 
         cur.execute("describe table example")
 

--- a/tests/test_write_pandas.py
+++ b/tests/test_write_pandas.py
@@ -88,18 +88,15 @@ def test_write_pandas_float16_null(conn: snowflake.connector.SnowflakeConnection
         assert cur.fetchall() == [(b"\x00>",), (None,)]
 
 
-@pytest.mark.parametrize("columns", [["HALF"], ["HALF", "OTHER"], ["OTHER", "HALF"]])
-def test_write_pandas_float16_use_logical_type(conn: snowflake.connector.SnowflakeConnection, columns: list[str]):
-    # infer_schema returns no columns for a staged half float under USE_LOGICAL_TYPE = TRUE, so
-    # snowflake's own write_pandas raises a KeyError naming the first column, whichever it is
-    df = pd.DataFrame({c: pd.Series([1.5], dtype="float16" if c == "HALF" else "float32") for c in columns})
+def test_write_pandas_float16_use_logical_type(conn: snowflake.connector.SnowflakeConnection):
+    # snowflake's infer_schema returns no columns for a staged half float under
+    # USE_LOGICAL_TYPE = TRUE, so it can't create the table either
+    df = pd.DataFrame({"C": pd.Series([1.5], dtype="float16")})
 
-    with pytest.raises(KeyError) as excinfo:
+    with pytest.raises(NotImplementedError, match=r"sql_type dtype=dtype\('float16'\) use_logical_type=True"):
         snowflake.connector.pandas_tools.write_pandas(
             conn, df, "EXAMPLE", auto_create_table=True, use_logical_type=True
         )
-
-    assert excinfo.value.args == (columns[0],)
 
 
 def test_write_pandas_auto_create_timestamps(conn: snowflake.connector.SnowflakeConnection):


### PR DESCRIPTION
Fixes #399

Snowflake only reads a staged parquet time or timestamp with nanosecond precision as a `TIME`/`TIMESTAMP` column when `USE_LOGICAL_TYPE = TRUE`. Without this argument, it infers a `NUMBER`, as an offset from UNIX epoch.  

`sql_type` will continue to raise for temporal dtypes unless `use_logical_type=True` is passed to avoid more extensive mapping logic.

*Notes:*

- **`float16` w/ `use_logical_type=true`:** `sql_type()` now raises `NotImplementedError` for this combination. `snowflake-connector-python.write_pandas()` raises an in-Python `KeyError` in this case (no actual Snowflake error), seems to be due to `INFER_SCHEMA` [returning nothing](https://docs.snowflake.com/en/sql-reference/functions/infer_schema) in this case. 
- **`TIMESTAMP_TZ vs TIMESTAMP_LTZ`:** I have one test case which is an `xfail` right now, where DuckDB is reporting a timezone aware timestamp as `_TZ` vs. how Snowflake would describe it as `_LTZ`, this can be addressed in a follow-up issue/PR. 

Verified against a live warehouse: the same column types and values for every test here. 

Made with [Cursor](https://cursor.com)