### PR TITLE
fix: report the rows affected by a MERGE as the total across its operations

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -622,6 +622,10 @@ class FakeSnowflakeCursor:
             self._duck_conn.execute(result_sql)
 
         self._arrow_table = self._duck_conn.to_arrow_table()
+        if transformed.args.get("merge_counts"):
+            # a merge returns a count per operation, but snowflake reports their total as the
+            # rows affected, not the single row those counts are in
+            affected_count = int(sum(c[0].as_py() for c in self._arrow_table.columns))
         self._rowcount = affected_count or self._arrow_table.num_rows
         self._sfqid = str(uuid.uuid4())
 

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -139,7 +139,7 @@ async def query_request(request: Request) -> JSONResponse:
                 # across the whole batch, so accumulate them as we execute row by row
                 for row in batch:
                     await run_in_threadpool(cur.execute, sql_text, binding_params=row, server=True)
-                    batch_rowcount += cur._rowcount or 0  # noqa: SLF001
+                    batch_rowcount += cur.rowcount or 0
             rowtype = describe_as_rowtype(cur._describe_last_sql())  # noqa: SLF001
 
             expr = cur._last_transformed  # noqa: SLF001
@@ -203,7 +203,7 @@ async def query_request(request: Request) -> JSONResponse:
                         {"name": "TIMEZONE", "value": "Etc/UTC"},
                     ],
                     "rowtype": rowtype,
-                    "total": 1 if batch is not None else cur._rowcount,  # noqa: SLF001
+                    "total": 1 if batch is not None else cur.rowcount,
                     "queryId": cur.sfqid,
                     "statementTypeId": type_id,
                     "finalDatabaseName": conn.database,

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -220,4 +220,8 @@ def _counts(merge_expr: exp.Merge) -> Expr:
     FROM merge_candidates
     """
 
-    return sqlglot.parse_one(sql)
+    counts = sqlglot.parse_one(sql)
+    # marks the statement that produces the merge result, so the cursor can report the rows
+    # affected across all the operations rather than the single row of counts
+    counts.set("merge_counts", True)
+    return counts

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -647,3 +647,39 @@ def test_merge_delete_lowercase(conn: snowflake.connector.SnowflakeConnection):
 
         cur.execute("select id from t order by id")
         assert cur.fetchall() == [(2,)]
+
+
+def test_merge_rowcount(conn: snowflake.connector.SnowflakeConnection):
+    # snowflake reports the rows affected across all the merge operations, not the single row
+    # the counts are returned in
+    with conn.cursor() as cur:
+
+        def reset() -> None:
+            cur.execute("create or replace table t (id int, v int)")
+            cur.execute("insert into t values (1, 10), (2, 20)")
+
+        matched_and_not = """
+            merge into t using (select 1 as id, 99 as v union all select 3, 30) s on t.id = s.id
+            when matched then update set t.v = s.v
+            when not matched then insert values (s.id, s.v)
+            """
+
+        reset()
+        cur.execute(matched_and_not)
+        assert cur.fetchall() == [(1, 1)]
+        assert cur.rowcount == 2
+
+        reset()
+        cur.execute("merge into t using (select 1 as id) s on t.id = s.id when matched then delete")
+        assert cur.fetchall() == [(1,)]
+        assert cur.rowcount == 1
+
+        reset()
+        cur.execute("""
+            merge into t using (select 1 as id, 99 as v union all select 3, 30) s on t.id = s.id
+            when matched and s.v > 50 then update set t.v = s.v
+            when matched then delete
+            when not matched then insert values (s.id, s.v)
+            """)
+        assert cur.fetchall() == [(1, 1, 0)]
+        assert cur.rowcount == 2

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -496,23 +496,6 @@ def test_server_query_response_has_use_statement_type_id(server: dict, sql: str)
     assert result["data"]["statementTypeId"] == 0x4300
 
 
-def test_server_rowcount_dml(scur: snowflake.connector.cursor.SnowflakeCursor):
-    cur = scur
-
-    cur.execute("create or replace table example (id int)")
-    cur.execute("insert into example values (1), (2), (3)")
-    assert cur.rowcount == 3
-    cur.execute("update example set id = 9 where id > 1")
-    assert cur.rowcount == 2
-    cur.execute("delete from example where id = 9")
-    assert cur.rowcount == 2
-    cur.execute(
-        "merge into example t using (select 1 as id union all select 7 as id) s on t.id = s.id "
-        "when matched then update set t.id = 5 when not matched then insert (id) values (s.id)"
-    )
-    # 1 row inserted + 1 row updated
-    assert cur.rowcount == 2
-
 
 def test_server_sfid(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
     cur = scur

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -496,7 +496,6 @@ def test_server_query_response_has_use_statement_type_id(server: dict, sql: str)
     assert result["data"]["statementTypeId"] == 0x4300
 
 
-
 def test_server_sfid(scur: snowflake.connector.cursor.SnowflakeCursor) -> None:
     cur = scur
     assert not cur.sfqid


### PR DESCRIPTION
In local mode `cursor.rowcount` is 1 for every merge, whatever it did. The merge result is a single row holding a count per operation, and that row was counted rather than the counts in it.

An account reports the total across the operations:

| merge | result row | rowcount |
| --- | --- | --- |
| matched update + not matched insert | `(1, 1)` | 2 |
| matched delete | `(1,)` | 1 |
| update + insert + delete | `(1, 1, 0)` | 2 |

Marked the statement that produces those counts in the merge transform, the same way the other transforms flag statements they need the cursor to treat specially, and summed them there.

The server was already correct because the connector sums the counts from the rowset itself, which `test_server_rowcount_dml` covers. This is local mode only.

One thing worth noting: the sum comes back as a `Decimal`, and returning that as `rowcount` broke the server's JSON response, so it's cast to `int`. `test_server_rowcount_dml` caught it.
