### PR TITLE
fix: MERGE returns integer counts when no rows are affected

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -626,7 +626,7 @@ class FakeSnowflakeCursor:
             # a merge returns a count per operation, but snowflake reports their total as the
             # rows affected, not the single row those counts are in
             affected_count = int(sum(c[0].as_py() for c in self._arrow_table.columns))
-        self._rowcount = affected_count or self._arrow_table.num_rows
+        self._rowcount = affected_count if affected_count is not None else self._arrow_table.num_rows
         self._sfqid = str(uuid.uuid4())
 
         self._last_sql = result_sql or sql

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -203,7 +203,7 @@ async def query_request(request: Request) -> JSONResponse:
                         {"name": "TIMEZONE", "value": "Etc/UTC"},
                     ],
                     "rowtype": rowtype,
-                    "total": 1 if batch is not None else cur.rowcount,
+                    "total": 1 if batch is not None else arrow_table.num_rows if arrow_table else 0,
                     "queryId": cur.sfqid,
                     "statementTypeId": type_id,
                     "finalDatabaseName": conn.database,

--- a/fakesnow/transforms/merge.py
+++ b/fakesnow/transforms/merge.py
@@ -210,8 +210,10 @@ def _counts(merge_expr: exp.Merge) -> Expr:
 
     ops = operations(merge_expr)
 
+    # COALESCE because duckdb's COUNT_IF returns NULL for an empty merge_candidates table,
+    # whereas snowflake always returns integer counts
     count_statements = [
-        f"""COUNT_IF(merge_op in ({",".join(map(str, indices))})) as \"number of rows {op}\""""
+        f"""COALESCE(COUNT_IF(merge_op in ({",".join(map(str, indices))})), 0) as \"number of rows {op}\""""
         for op, indices in ops.items()
         if indices
     ]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -62,9 +62,9 @@ def test_transform_merge() -> None:
             WHERE t2.merge_op = 3"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (3)) AS "number of rows inserted",
-              COUNT_IF(merge_op IN (1, 2)) AS "number of rows updated",
-              COUNT_IF(merge_op IN (0)) AS "number of rows deleted"
+              COALESCE(COUNT_IF(merge_op IN (3)), 0) AS "number of rows inserted",
+              COALESCE(COUNT_IF(merge_op IN (1, 2)), 0) AS "number of rows updated",
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows deleted"
             FROM merge_candidates"""),
     ]
 
@@ -121,9 +121,9 @@ def test_transform_merge_table_alias_target() -> None:
             WHERE t2.merge_op = 3"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (3)) AS "number of rows inserted",
-              COUNT_IF(merge_op IN (1, 2)) AS "number of rows updated",
-              COUNT_IF(merge_op IN (0)) AS "number of rows deleted"
+              COALESCE(COUNT_IF(merge_op IN (3)), 0) AS "number of rows inserted",
+              COALESCE(COUNT_IF(merge_op IN (1, 2)), 0) AS "number of rows updated",
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows deleted"
             FROM merge_candidates"""),
     ]
 
@@ -180,9 +180,9 @@ def test_transform_merge_table_alias_source() -> None:
             WHERE t2.merge_op = 3"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (3)) AS "number of rows inserted",
-              COUNT_IF(merge_op IN (1, 2)) AS "number of rows updated",
-              COUNT_IF(merge_op IN (0)) AS "number of rows deleted"
+              COALESCE(COUNT_IF(merge_op IN (3)), 0) AS "number of rows inserted",
+              COALESCE(COUNT_IF(merge_op IN (1, 2)), 0) AS "number of rows updated",
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows deleted"
             FROM merge_candidates"""),
     ]
 
@@ -216,7 +216,7 @@ def test_transform_merge_not_matched_condition() -> None:
             WHERE t2.merge_op = 0"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (0)) AS "number of rows inserted"
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows inserted"
             FROM merge_candidates"""),
     ]
 
@@ -261,8 +261,8 @@ def test_transform_merge_complex_join_keys() -> None:
             WHERE t2.merge_op = 1"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (1)) AS "number of rows inserted",
-              COUNT_IF(merge_op IN (0)) AS "number of rows deleted"
+              COALESCE(COUNT_IF(merge_op IN (1)), 0) AS "number of rows inserted",
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows deleted"
             FROM merge_candidates"""),
     ]
 
@@ -305,7 +305,7 @@ def test_transform_merge_source_subquery() -> None:
             AND src.merge_op = 0"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (0)) AS "number of rows updated"
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows updated"
             FROM merge_candidates"""),
     ]
 
@@ -362,9 +362,9 @@ def test_transform_merge_join_function() -> None:
             WHERE t2.merge_op = 3"""),
         strip("""
             SELECT
-              COUNT_IF(merge_op IN (3)) AS "number of rows inserted",
-              COUNT_IF(merge_op IN (1, 2)) AS "number of rows updated",
-              COUNT_IF(merge_op IN (0)) AS "number of rows deleted"
+              COALESCE(COUNT_IF(merge_op IN (3)), 0) AS "number of rows inserted",
+              COALESCE(COUNT_IF(merge_op IN (1, 2)), 0) AS "number of rows updated",
+              COALESCE(COUNT_IF(merge_op IN (0)), 0) AS "number of rows deleted"
             FROM merge_candidates"""),
     ]
 
@@ -683,3 +683,21 @@ def test_merge_rowcount(conn: snowflake.connector.SnowflakeConnection):
             """)
         assert cur.fetchall() == [(1, 1, 0)]
         assert cur.rowcount == 2
+
+
+def test_merge_no_rows_affected_returns_integer_counts(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE OR REPLACE TABLE t1 (id INT, name VARCHAR)")
+    dcur.execute("CREATE OR REPLACE TABLE s1 (id INT, name VARCHAR)")
+    dcur.execute("INSERT INTO s1 VALUES (1, 'a')")
+
+    merge = """
+        MERGE INTO t1 USING s1 ON t1.id = s1.id
+        WHEN MATCHED AND t1.name IS DISTINCT FROM s1.name THEN UPDATE SET name = s1.name
+        WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s1.id, s1.name)
+    """
+    dcur.execute(merge)
+    assert dcur.fetchall() == [{"number of rows inserted": 1, "number of rows updated": 0}]
+
+    # rerun: no clause affects any row, but the counts are integers, never NULL
+    dcur.execute(merge)
+    assert dcur.fetchall() == [{"number of rows inserted": 0, "number of rows updated": 0}]

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -701,3 +701,4 @@ def test_merge_no_rows_affected_returns_integer_counts(dcur: snowflake.connector
     # rerun: no clause affects any row, but the counts are integers, never NULL
     dcur.execute(merge)
     assert dcur.fetchall() == [{"number of rows inserted": 0, "number of rows updated": 0}]
+    assert dcur.rowcount == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -658,24 +658,3 @@ def test_server_describe_only(server: dict) -> None:
         # nothing ran: the original table is untouched
         cur.execute("select * from example")
         assert cur.fetchall() == [(1, "old")]
-
-
-def test_server_merge_no_rows_affected(sdcur: snowflake.connector.cursor.DictCursor) -> None:
-    # the connector reads the counts client-side with int(), so they must never be NULL
-    dcur = sdcur
-    dcur.execute("CREATE OR REPLACE TABLE t1 (id INT, name VARCHAR)")
-    dcur.execute("CREATE OR REPLACE TABLE s1 (id INT, name VARCHAR)")
-    dcur.execute("INSERT INTO s1 VALUES (1, 'a')")
-
-    merge = """
-        MERGE INTO t1 USING s1 ON t1.id = s1.id
-        WHEN MATCHED AND t1.name IS DISTINCT FROM s1.name THEN UPDATE SET name = s1.name
-        WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s1.id, s1.name)
-    """
-    dcur.execute(merge)
-    assert dcur.fetchall() == [{"number of rows inserted": 1, "number of rows updated": 0}]
-
-    # rerun: no clause affects any row
-    dcur.execute(merge)
-    assert dcur.fetchall() == [{"number of rows inserted": 0, "number of rows updated": 0}]
-    assert dcur.rowcount == 0

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -196,6 +196,26 @@ def test_server_executemany_qmark(server: dict) -> None:
         ]
 
 
+def test_server_merge_response_total(sconn: snowflake.connector.SnowflakeConnection) -> None:
+    conn = sconn
+    with conn.cursor() as cur:
+        cur.execute("create table target (id int, name varchar)")
+        cur.execute("create table source (id int, name varchar)")
+        cur.execute("insert into source values (1, 'a')")
+
+        merge = """
+            merge into target using source on target.id = source.id
+            when matched and target.name is distinct from source.name then update set name = source.name
+            when not matched then insert (id, name) values (source.id, source.name)
+        """
+        cur.execute(merge)
+
+    result = conn.cmd_query(merge, conn._next_sequence_counter(), uuid.uuid4())  # noqa: SLF001
+
+    # A zero-effect MERGE still returns one row of operation counts.
+    assert result["data"]["total"] == 1
+
+
 def test_server_close(server: dict) -> None:
     conn = snowflake.connector.connect(**server)
 

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -658,3 +658,24 @@ def test_server_describe_only(server: dict) -> None:
         # nothing ran: the original table is untouched
         cur.execute("select * from example")
         assert cur.fetchall() == [(1, "old")]
+
+
+def test_server_merge_no_rows_affected(sdcur: snowflake.connector.cursor.DictCursor) -> None:
+    # the connector reads the counts client-side with int(), so they must never be NULL
+    dcur = sdcur
+    dcur.execute("CREATE OR REPLACE TABLE t1 (id INT, name VARCHAR)")
+    dcur.execute("CREATE OR REPLACE TABLE s1 (id INT, name VARCHAR)")
+    dcur.execute("INSERT INTO s1 VALUES (1, 'a')")
+
+    merge = """
+        MERGE INTO t1 USING s1 ON t1.id = s1.id
+        WHEN MATCHED AND t1.name IS DISTINCT FROM s1.name THEN UPDATE SET name = s1.name
+        WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s1.id, s1.name)
+    """
+    dcur.execute(merge)
+    assert dcur.fetchall() == [{"number of rows inserted": 1, "number of rows updated": 0}]
+
+    # rerun: no clause affects any row
+    dcur.execute(merge)
+    assert dcur.fetchall() == [{"number of rows inserted": 0, "number of rows updated": 0}]
+    assert dcur.rowcount == 0


### PR DESCRIPTION
duckdb's `COUNT_IF` returns NULL over an empty `merge_candidates` table, which crashed clients that read the counts, eg: snowflake-connector-python calls `int()` on them. Snowflake always returns integers, so wrap each count in `COALESCE(..., 0)`.

Regression tests cover both local mode and the server/connector path (where the `int()` crash happened).

Fixes #406. Split out of #400 per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
