### PR TITLE
fix: scope load history to the target table

### DIFF
--- a/fakesnow/copy_into.py
+++ b/fakesnow/copy_into.py
@@ -90,11 +90,14 @@ def copy_into(
     histories: list[LoadHistoryRecord] = []
     load_time = datetime.datetime.now(datetime.timezone.utc).isoformat()
     try:
-        check_sql = "SELECT 1 FROM _fs_information_schema._fs_load_history WHERE FILE_NAME = ? LIMIT 1"
+        check_sql = (
+            "SELECT 1 FROM _fs_information_schema._fs_load_history "
+            "WHERE FILE_NAME = ? AND TABLE_NAME = ? AND SCHEMA_NAME = ? LIMIT 1"
+        )
 
         for i, url in zip(inserts, urls, strict=False):
-            # Check if file has been loaded into any table before
-            duck_conn.execute(check_sql, [url])
+            # Check if file has been loaded into this table before
+            duck_conn.execute(check_sql, [url, table.name, schema])
             if duck_conn.fetchone() and not cparams.force:
                 affected_count = 0
                 status = "LOAD_SKIPPED"

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -574,6 +574,17 @@ class FakeSnowflakeCursor:
             elif cmd == "CREATE TABLE" and ident:
                 result_sql = SQL_CREATED_TABLE.substitute(name=ident)
 
+                # a newly created table object has no load history
+                if table := transformed.find(exp.Table):
+                    catalog = table.catalog or self._conn.database
+                    schema = table.db or self._conn.schema
+                    assert catalog and schema
+                    self._duck_conn.execute(
+                        f"DELETE FROM {catalog}._fs_information_schema._fs_load_history "
+                        "WHERE SCHEMA_NAME = ? AND TABLE_NAME = ?",
+                        [schema, table.name],
+                    )
+
             elif cmd.startswith("ALTER") and ident:
                 result_sql = SQL_SUCCESS
 

--- a/tests/test_copy_into.py
+++ b/tests/test_copy_into.py
@@ -766,6 +766,35 @@ def test_params_files_multiple():
     assert _source_urls(from_source, params.files) == ["s3://mybucket/data/file1.csv", "s3://mybucket/data/file2.csv"]
 
 
+def test_load_history_is_per_table(dcur: snowflake.connector.cursor.DictCursor, s3_client: S3Client) -> None:
+    create_table(dcur)
+    bucket = str(uuid.uuid4())
+    upload_file(s3_client, "1,2", bucket=bucket, key="foo.csv")
+
+    sql = """
+    COPY INTO {table}
+    FROM 's3://{bucket}/'
+    FILES=('foo.csv')
+    """
+
+    dcur.execute(sql.format(table="table1", bucket=bucket))
+    assert dcur.fetchall()[0]["status"] == "LOADED"
+
+    # reloading the same file into the same table skips it
+    dcur.execute(sql.format(table="table1", bucket=bucket))
+    assert dcur.fetchall()[0]["status"] == "LOAD_SKIPPED"
+
+    # but loading it into another table is not skipped
+    dcur.execute("CREATE TABLE schema1.table2 (a INT, b INT)")
+    dcur.execute(sql.format(table="table2", bucket=bucket))
+    assert dcur.fetchall()[0]["status"] == "LOADED"
+
+    # recreating the table resets its load history
+    dcur.execute("CREATE OR REPLACE TABLE schema1.table1 (a INT, b INT)")
+    dcur.execute(sql.format(table="table1", bucket=bucket))
+    assert dcur.fetchall()[0]["status"] == "LOADED"
+
+
 def test__strip_json_extract():
     sql = 'SELECT $1:"A"::integer, $1:"B"::integer FROM @stage1'
 


### PR DESCRIPTION
Snowflake tracks load metadata per table, so the same file loaded into a different table is not skipped, and recreating a table resets its load history.

The dedup check now matches on file name, table name and schema, and `CREATE TABLE` clears the table's load-history rows.

Fixes #407. Split out of #400 per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
