### PR TITLE
feat: CREATE OR REPLACE STAGE, named file formats, and more CSV options in COPY INTO

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Partially supported:
 - Tags
 - User management
 - Stages and PUT
+- Named file formats
 - `COPY INTO` from S3 sources and stages, see [COPY INTO](#copy-into)
 
 Not yet implemented:

--- a/fakesnow/checks.py
+++ b/fakesnow/checks.py
@@ -84,8 +84,8 @@ def _missing_qualifiers(node: exp.Table) -> tuple[bool, bool]:
             # "CREATE/DROP SCHEMA"
             no_database = not node.args.get("catalog")
             no_schema = False
-        elif parent_kind.upper() in {"TABLE", "VIEW", "STAGE", "TAG", "SEQUENCE"}:
-            # "CREATE/DROP TABLE/VIEW/STAGE/TAG"
+        elif parent_kind.upper() in {"TABLE", "VIEW", "STAGE", "TAG", "SEQUENCE", "FILE FORMAT"}:
+            # "CREATE/DROP TABLE/VIEW/STAGE/TAG/FILE FORMAT"
             no_database = not node.args.get("catalog")
             no_schema = not node.args.get("db")
         else:

--- a/fakesnow/copy_into.py
+++ b/fakesnow/copy_into.py
@@ -17,6 +17,7 @@ from sqlglot import Expr, exp
 import fakesnow.transforms.stage as stage
 from fakesnow import logger
 from fakesnow.params import MutableParams, pop_qmark_param
+from fakesnow.transforms.file_format import format_options, lookup_file_format
 
 Params = Sequence[Any] | dict[Any, Any]
 
@@ -46,7 +47,9 @@ def copy_into(
     expr: exp.Copy,
     params: MutableParams | None = None,
 ) -> str:
-    cparams = _params(expr, params)
+    cparams = _params(
+        expr, params, duck_conn=duck_conn, current_database=current_database, current_schema=current_schema
+    )
 
     from_source = _from_source(expr)
     source = (
@@ -206,7 +209,13 @@ def _get_table_columns(
     return [col[0].upper() for col in columns]
 
 
-def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
+def _params(
+    expr: exp.Copy,
+    params: MutableParams | None = None,
+    duck_conn: DuckDBPyConnection | None = None,
+    current_database: str | None = None,
+    current_schema: str | None = None,
+) -> CopyParams:
     kwargs = {}
     force = False
     purge = False
@@ -220,12 +229,16 @@ def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
             if kwargs.get("file_format"):
                 raise ValueError(cparams)
 
-            var_type = next((e.args["value"].this for e in param.expressions if e.this.this == "TYPE"), None)
-            if not var_type:
-                raise NotImplementedError("FILE_FORMAT without TYPE is not currently implemented")
+            options = format_options(list(param.expressions))
+            if format_name := options.pop("FORMAT_NAME", None):
+                if options.get("TYPE"):
+                    raise ValueError("Cannot specify both FORMAT_NAME and TYPE in FILE_FORMAT")
+                assert duck_conn, "duck_conn is required to resolve FORMAT_NAME"
+                options = lookup_file_format(duck_conn, str(format_name), current_database, current_schema)
 
+            var_type = str(options.get("TYPE", "CSV")).upper()
             if var_type == "CSV":
-                kwargs["file_format"] = handle_csv(param.expressions)
+                kwargs["file_format"] = handle_csv(options)
             elif var_type == "PARQUET":
                 kwargs["file_format"] = ReadParquet()
             else:
@@ -237,7 +250,7 @@ def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
         elif var == "PURGE":
             purge = True
         elif var == "ON_ERROR":
-            if isinstance(param.expression, exp.Var):
+            if isinstance(param.expression, (exp.Var, exp.Literal)):
                 on_error = param.expression.name.upper()
             elif isinstance(param.expression, exp.Placeholder):
                 on_error = pop_qmark_param(params, expr, param.expression)
@@ -296,7 +309,9 @@ def _from_source(expr: exp.Copy) -> str:
 def stage_url_from_var(
     var: str, duck_conn: DuckDBPyConnection, current_database: str | None, current_schema: str | None
 ) -> str:
-    database_name, schema_name, name = stage.parts_from_var(var, current_database, current_schema)
+    # a stage reference can include a path suffix, eg: @stage1/dir/file.csv.gz
+    stage_var, _, path = var.partition("/")
+    database_name, schema_name, name = stage.parts_from_var(stage_var, current_database, current_schema)
 
     # Look up the stage URL
     duck_conn.execute(
@@ -308,7 +323,8 @@ def stage_url_from_var(
     )
     if result := duck_conn.fetchone():
         # if no URL is found, it is an internal stage ie: local directory
-        return result[0] or stage.internal_dir(f"{database_name}.{schema_name}.{name}")
+        url = result[0] or stage.internal_dir(f"{database_name}.{schema_name}.{name}")
+        return f"{url.rstrip('/')}/{path}" if path else url
     else:
         raise snowflake.connector.errors.ProgrammingError(
             msg=f"SQL compilation error:\nStage '{database_name}.{schema_name}.{name}' does not exist or not authorized.",  # noqa: E501
@@ -331,11 +347,13 @@ def _source_urls(source: str, files: list[str]) -> list[str]:
 
 def _source_glob(source: str, duck_conn: DuckDBPyConnection) -> list[str]:
     """List files from the source using duckdb glob."""
+    is_internal_file = stage.is_internal(source) and not os.path.isdir(source)
     if stage.is_internal(source):
         source = Path(source).as_uri()  # convert local directory to a file URL
 
     scheme, _netloc, _path, _params, _query, _fragment = urlparse(source)
-    glob = f"{source}/*" if scheme == "file" else f"{source}*"
+    # a stage path suffix is a prefix match, eg: @stage1/dir/file matches dir/file*
+    glob = f"{source}/*" if scheme == "file" and not is_internal_file else f"{source}*"
     sql = f"SELECT file FROM glob('{glob}')"
     logger.log_sql(sql)
     result = duck_conn.execute(sql).fetchall()
@@ -514,29 +532,57 @@ def _strip_json_extract(expr: exp.Select) -> exp.Select:
     return expr
 
 
-def handle_csv(expressions: list[exp.Property]) -> ReadCSV:
+def handle_csv(options: dict[str, Any]) -> ReadCSV:
     skip_header = ReadCSV.skip_header
     quote = ReadCSV.quote
     delimiter = ReadCSV.delimiter
+    null_if: list[str] | None = None
+    compression: str | None = None
+    empty_field_as_null = True
 
-    for expression in expressions:
-        exp_type = expression.name
-        if exp_type in {"TYPE"}:
+    for name, value in options.items():
+        if name == "TYPE":
             continue
 
-        elif exp_type == "SKIP_HEADER":
-            skip_header = True
-        elif exp_type == "FIELD_OPTIONALLY_ENCLOSED_BY":
-            quote = expression.args["value"].this
-        elif exp_type == "FIELD_DELIMITER":
-            delimiter = expression.args["value"].this
+        elif name == "SKIP_HEADER":
+            skip_header = int(value)
+        elif name == "FIELD_OPTIONALLY_ENCLOSED_BY":
+            quote = str(value)
+        elif name == "FIELD_DELIMITER":
+            delimiter = str(value)
+        elif name == "NULL_IF":
+            null_if = [str(v) for v in value] if isinstance(value, list) else [str(value)]
+        elif name == "EMPTY_FIELD_AS_NULL":
+            empty_field_as_null = bool(value)
+        elif name == "ESCAPE_UNENCLOSED_FIELD":
+            # duckdb does not escape unenclosed fields, which matches ESCAPE_UNENCLOSED_FIELD = NONE
+            if str(value).upper() != "NONE":
+                raise NotImplementedError(f"ESCAPE_UNENCLOSED_FIELD = {value} is not currently implemented")
+        elif name == "COMPRESSION":
+            comp = str(value).upper()
+            if comp in {"GZIP", "NONE"}:
+                compression = comp.lower()
+            elif comp not in {"AUTO", "AUTO_DETECT"}:
+                # AUTO matches duckdb's default of detecting compression from the file extension
+                raise NotImplementedError(f"COMPRESSION = {value} is not currently implemented")
         else:
-            raise NotImplementedError(f"{exp_type} is not currently implemented")
+            raise NotImplementedError(f"{name} is not currently implemented")
+
+    # empty fields are null by default in duckdb (nullstr = ''), matching EMPTY_FIELD_AS_NULL = TRUE
+    if empty_field_as_null:
+        if null_if is not None and "" not in null_if:
+            null_if = ["", *null_if]
+    elif null_if is None:
+        null_if = []
+    elif "" in null_if:
+        raise NotImplementedError("EMPTY_FIELD_AS_NULL = FALSE with NULL_IF containing '' is not currently implemented")
 
     return ReadCSV(
         skip_header=skip_header,
         quote=quote,
         delimiter=delimiter,
+        null_if=null_if,
+        compression=compression,
     )
 
 
@@ -558,16 +604,18 @@ class FileTypeHandler(Protocol):
 
 @dataclass
 class ReadCSV(FileTypeHandler):
-    skip_header: bool = False
+    skip_header: int = 0
     quote: str | None = None
     delimiter: str = ","
+    null_if: list[str] | None = None
+    compression: str | None = None
 
     def read_expression(self, url: str) -> Expr:
         # don't parse header and use as column names, keep them as column0, column1, etc
         args = [self.make_eq("header", False)]
 
         if self.skip_header:
-            args.append(self.make_eq("skip", 1))
+            args.append(self.make_eq("skip", self.skip_header))
 
         if self.quote:
             quote = self.quote.replace("'", "''")
@@ -576,6 +624,12 @@ class ReadCSV(FileTypeHandler):
         if self.delimiter and self.delimiter != ",":
             delimiter = self.delimiter.replace("'", "''")
             args.append(self.make_eq("sep", delimiter))
+
+        if self.null_if is not None:
+            args.append(self.make_eq("nullstr", [v.replace("'", "''") for v in self.null_if]))
+
+        if self.compression:
+            args.append(self.make_eq("compression", self.compression))
 
         return exp.func("read_csv", exp.Literal(this=url, is_string=True), *args)
 

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -54,6 +54,7 @@ SQL_CREATED_TABLE = Template("SELECT 'Table ${name} successfully created.' as 's
 SQL_CREATED_VIEW = Template("SELECT 'View ${name} successfully created.' as 'status'")
 SQL_CREATED_STAGE = Template("SELECT 'Stage area ${name} successfully created.' as status")
 SQL_OBJECT_EXISTS = Template("SELECT '${name} already exists, statement succeeded.' as status")
+SQL_CREATED_FILE_FORMAT = Template("SELECT 'File format ${name} successfully created.' as status")
 SQL_DROPPED = Template("SELECT '${name} successfully dropped.' as 'status'")
 SQL_INSERTED_ROWS = Template("SELECT ${count} as 'number of rows inserted'")
 SQL_UPDATED_ROWS = Template("SELECT ${count} as 'number of rows updated', 0 as 'number of multi-joined rows updated'")
@@ -370,6 +371,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.alter_table_strip_cluster_by)
             .transform(transforms.numeric_agg_implicit_cast)
             .transform(lambda e: transforms.create_stage(e, self._conn.database, self._conn.schema))
+            .transform(lambda e: transforms.create_file_format(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.list_stage(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.put_stage(e, self._conn.database, self._conn.schema, params))
             .transform(lambda e: transforms.create_table_as(e, self._duck_conn))
@@ -443,8 +445,10 @@ class FakeSnowflakeCursor:
             # see https://docs.snowflake.com/en/sql-reference/transactions#ddl
             # and https://docs.snowflake.com/en/sql-reference/sql-ddl-summary
             # TODO: include DESCRIBE, SHOW, USE in this list of DDL statements
-            if isinstance(transformed, (exp.Alter, exp.Comment, exp.Create, exp.Drop)) or transformed.args.get(
-                "create_stage_name"
+            if (
+                isinstance(transformed, (exp.Alter, exp.Comment, exp.Create, exp.Drop))
+                or transformed.args.get("create_stage_name")
+                or transformed.args.get("create_file_format_name")
             ):
                 self._duck_conn.commit()
                 self._conn._in_transaction = False
@@ -455,6 +459,7 @@ class FakeSnowflakeCursor:
             elif (
                 isinstance(transformed, (exp.Insert, exp.Update, exp.Delete, exp.Merge, exp.Copy))
                 and not transformed.args.get("create_stage_name")
+                and not transformed.args.get("create_file_format_name")
                 and not self._conn._in_transaction
             ):
                 self._duck_conn.begin()
@@ -529,6 +534,19 @@ class FakeSnowflakeCursor:
             else:
                 raise snowflake.connector.errors.ProgrammingError(
                     msg=f"SQL compilation error:\nObject '{stage_name}' already exists.",
+                    errno=2002,
+                    sqlstate="42710",
+                )
+
+        elif format_name := transformed.args.get("create_file_format_name"):
+            (affected_count,) = self._duck_conn.fetchall()[0]
+            if affected_count > 0:
+                result_sql = SQL_CREATED_FILE_FORMAT.substitute(name=format_name)
+            elif transformed.args.get("create_file_format_if_not_exists"):
+                result_sql = SQL_OBJECT_EXISTS.substitute(name=format_name)
+            else:
+                raise snowflake.connector.errors.ProgrammingError(
+                    msg=f"SQL compilation error:\nObject '{format_name}' already exists.",
                     errno=2002,
                     sqlstate="42710",
                 )

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -53,6 +53,7 @@ SQL_CREATED_SECRET = Template("SELECT 'Secret ${name} successfully created.' as 
 SQL_CREATED_TABLE = Template("SELECT 'Table ${name} successfully created.' as 'status'")
 SQL_CREATED_VIEW = Template("SELECT 'View ${name} successfully created.' as 'status'")
 SQL_CREATED_STAGE = Template("SELECT 'Stage area ${name} successfully created.' as status")
+SQL_OBJECT_EXISTS = Template("SELECT '${name} already exists, statement succeeded.' as status")
 SQL_DROPPED = Template("SELECT '${name} successfully dropped.' as 'status'")
 SQL_INSERTED_ROWS = Template("SELECT ${count} as 'number of rows inserted'")
 SQL_UPDATED_ROWS = Template("SELECT ${count} as 'number of rows updated', 0 as 'number of multi-joined rows updated'")
@@ -521,13 +522,16 @@ class FakeSnowflakeCursor:
 
         elif stage_name := transformed.args.get("create_stage_name"):
             (affected_count,) = self._duck_conn.fetchall()[0]
-            if affected_count == 0:
+            if affected_count > 0:
+                result_sql = SQL_CREATED_STAGE.substitute(name=stage_name)
+            elif transformed.args.get("create_stage_if_not_exists"):
+                result_sql = SQL_OBJECT_EXISTS.substitute(name=stage_name)
+            else:
                 raise snowflake.connector.errors.ProgrammingError(
                     msg=f"SQL compilation error:\nObject '{stage_name}' already exists.",
                     errno=2002,
                     sqlstate="42710",
                 )
-            result_sql = SQL_CREATED_STAGE.substitute(name=stage_name)
 
         elif stage_name := transformed.args.get("list_stage_name") or transformed.args.get("put_stage_name"):
             if self._duck_conn.to_arrow_table().num_rows != 1:

--- a/fakesnow/info_schema.py
+++ b/fakesnow/info_schema.py
@@ -255,7 +255,8 @@ CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_stages (
     storage_integration TEXT,
     endpoint TEXT,
     owner_role_type TEXT,
-    directory_enabled TEXT
+    directory_enabled TEXT,
+    PRIMARY KEY (database_name, schema_name, name)
 );
 """
 

--- a/fakesnow/info_schema.py
+++ b/fakesnow/info_schema.py
@@ -260,6 +260,18 @@ CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_stages (
 );
 """
 
+SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_FILE_FORMATS_TABLE = """
+CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_file_formats (
+    created_on TIMESTAMPTZ,
+    name TEXT,
+    database_name TEXT,
+    schema_name TEXT,
+    type TEXT,
+    options TEXT,
+    PRIMARY KEY (database_name, schema_name, name)
+);
+"""
+
 
 def per_db_creation_sql(catalog: str) -> str:
     return f"""
@@ -279,7 +291,8 @@ def fs_global_creation_sql() -> str:
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_COLUMNS_EXT};
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_COLUMNS_VIEW};
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_USERS_TABLE};
-        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_STAGES_TABLE}
+        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_STAGES_TABLE};
+        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_FILE_FORMATS_TABLE}
     """
 
 

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -5,6 +5,9 @@ from fakesnow.transforms.ddl import (
     alter_table_strip_cluster_by as alter_table_strip_cluster_by,
     create_table_autoincrement as create_table_autoincrement,
 )
+from fakesnow.transforms.file_format import (
+    create_file_format as create_file_format,
+)
 from fakesnow.transforms.merge import merge as merge
 from fakesnow.transforms.show import (
     show_columns as show_columns,

--- a/fakesnow/transforms/file_format.py
+++ b/fakesnow/transforms/file_format.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Any
+
+import snowflake.connector.errors
+import sqlglot
+from duckdb import DuckDBPyConnection
+from sqlglot import Expr, exp
+
+from fakesnow.transforms.stage import parts_from_var
+
+
+def option_value(value: Expr | None) -> Any:  # noqa: ANN401
+    """Convert a file format option value expression to a python value."""
+    if isinstance(value, exp.Literal):
+        return value.this if value.is_string else int(value.this)
+    if isinstance(value, exp.Boolean):
+        return value.this
+    if isinstance(value, exp.Paren):
+        return [option_value(value.this)]
+    if isinstance(value, exp.Tuple):
+        return [option_value(e) for e in value.expressions]
+    if isinstance(value, exp.Var):
+        return value.this
+    raise NotImplementedError(f"{value.__class__.__name__} as a file format option value")
+
+
+def format_options(properties: list[Expr]) -> dict[str, Any]:
+    """Convert file format properties to a dict of option name -> python value."""
+    options: dict[str, Any] = {}
+    for prop in properties:
+        if isinstance(prop, exp.TemporaryProperty):
+            continue
+        assert isinstance(prop, exp.Property), f"{prop.__class__} is not a Property"
+        assert isinstance(prop.this, exp.Var), f"{prop.this.__class__} is not a Var"
+        options[prop.this.name.upper()] = option_value(prop.args.get("value"))
+    return options
+
+
+def create_file_format(
+    expression: Expr,
+    current_database: str | None,
+    current_schema: str | None,
+) -> Expr:
+    """Transform CREATE FILE FORMAT to an INSERT statement for the fake file formats table."""
+    if not (
+        isinstance(expression, exp.Create)
+        and (kind := expression.args.get("kind"))
+        and isinstance(kind, str)
+        and kind.upper() == "FILE FORMAT"
+        and (table := expression.find(exp.Table))
+    ):
+        return expression
+
+    ident = table.this
+    if not isinstance(ident, exp.Identifier):
+        raise snowflake.connector.errors.ProgrammingError(
+            msg=f"SQL compilation error:\nInvalid identifier type {ident.__class__.__name__} for file format name.",
+            errno=1003,
+            sqlstate="42000",
+        )
+
+    catalog = table.catalog or current_database
+    schema = table.db or current_schema
+    format_name = ident.this
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    replace = expression.args.get("replace")
+    if_not_exists = expression.args.get("exists")
+
+    properties = expression.args.get("properties") or []
+    options = format_options(list(properties))
+    format_type = str(options.get("TYPE", "CSV")).upper()
+    options_json = json.dumps(options).replace("'", "''")
+
+    guard = (
+        ""
+        if replace
+        else f"""
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _fs_global._fs_information_schema._fs_file_formats
+            WHERE name = '{format_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
+        )"""
+    )
+    insert_sql = f"""
+        INSERT {"OR REPLACE" if replace else ""} INTO _fs_global._fs_information_schema._fs_file_formats
+        (created_on, name, database_name, schema_name, type, options)
+        SELECT
+            '{now}', '{format_name}', '{catalog}', '{schema}', '{format_type}', '{options_json}'
+        {guard}
+        """
+    transformed = sqlglot.parse_one(insert_sql, read="duckdb")
+    transformed.args["create_file_format_name"] = format_name
+    transformed.args["create_file_format_if_not_exists"] = if_not_exists
+    return transformed
+
+
+def lookup_file_format(
+    duck_conn: DuckDBPyConnection,
+    name: str,
+    current_database: str | None,
+    current_schema: str | None,
+) -> dict[str, Any]:
+    """Return the stored options of a named file format.
+
+    Raises if the file format does not exist.
+    """
+    database_name, schema_name, format_name = parts_from_var(name, current_database, current_schema)
+
+    duck_conn.execute(
+        """
+        SELECT options FROM _fs_global._fs_information_schema._fs_file_formats
+        WHERE database_name = ? AND schema_name = ? AND name = ?
+        """,
+        (database_name, schema_name, format_name),
+    )
+    if result := duck_conn.fetchone():
+        return json.loads(result[0])
+
+    raise snowflake.connector.errors.ProgrammingError(
+        msg=f"SQL compilation error:\nFile format '{format_name}' does not exist or not authorized.",
+        errno=2003,
+        sqlstate="02000",
+    )

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import shutil
 import tempfile
 from pathlib import PurePath
 from typing import Any, TypedDict
@@ -111,6 +112,9 @@ def create_stage(
     transformed = sqlglot.parse_one(insert_sql, read="duckdb")
     transformed.args["create_stage_name"] = stage_name
     transformed.args["create_stage_if_not_exists"] = if_not_exists
+    if replace:
+        # a replaced stage starts empty
+        shutil.rmtree(internal_dir(f"{catalog}.{schema}.{stage_name}"), ignore_errors=True)
     return transformed
 
 

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -85,8 +85,20 @@ def create_stage(
 
     stage_type = ("EXTERNAL" if url else "INTERNAL") + (" TEMPORARY" if is_temp else "")
 
+    replace = expression.args.get("replace")
+    if_not_exists = expression.args.get("exists")
+
+    guard = (
+        ""
+        if replace
+        else f"""
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _fs_global._fs_information_schema._fs_stages
+            WHERE name = '{stage_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
+        )"""
+    )
     insert_sql = f"""
-        INSERT INTO _fs_global._fs_information_schema._fs_stages
+        INSERT {"OR REPLACE" if replace else ""} INTO _fs_global._fs_information_schema._fs_stages
         (created_on, name, database_name, schema_name, url, has_credentials, has_encryption_key, owner,
         comment, region, type, cloud, notification_channel, storage_integration, endpoint, owner_role_type,
         directory_enabled)
@@ -94,13 +106,11 @@ def create_stage(
             '{now}', '{stage_name}', '{catalog}', '{schema}', '{url}', 'N', 'N', 'SYSADMIN',
             '', NULL, '{stage_type}', {f"'{cloud}'" if cloud else "NULL"}, NULL, NULL, NULL, 'ROLE',
             'N'
-        WHERE NOT EXISTS (
-            SELECT 1 FROM _fs_global._fs_information_schema._fs_stages
-            WHERE name = '{stage_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
-        )
+        {guard}
         """
     transformed = sqlglot.parse_one(insert_sql, read="duckdb")
     transformed.args["create_stage_name"] = stage_name
+    transformed.args["create_stage_if_not_exists"] = if_not_exists
     return transformed
 
 

--- a/tests/test_copy_into.py
+++ b/tests/test_copy_into.py
@@ -18,7 +18,7 @@ from mypy_boto3_s3 import S3Client
 from sqlglot import exp
 
 from fakesnow import logger
-from fakesnow.copy_into import CopyParams, _from_source, _params, _source_urls, _strip_json_extract
+from fakesnow.copy_into import CopyParams, ReadCSV, _from_source, _params, _source_urls, _strip_json_extract
 from tests.utils import dindent
 
 
@@ -217,6 +217,51 @@ def test_copy_internal_stage_server(sdcur: snowflake.connector.cursor.DictCursor
         dcur.execute("LIST @stage3")
         results = dcur.fetchall()
         assert len(results) == 0
+
+
+def test_copy_internal_stage_format_name_and_path(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    create_table(dcur)
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as temp_file:
+        data = 'A,B\n"1",2\n,4\n'
+        temp_file.write(data)
+        temp_file.flush()
+        temp_file_path = temp_file.name
+        temp_file_basename = os.path.basename(temp_file_path)
+
+        dcur.execute("CREATE STAGE stage3")
+        dcur.execute(f"PUT 'file://{temp_file_path}' @stage3")
+        dcur.execute("""
+            CREATE FILE FORMAT my_csv_format TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1
+            FIELD_OPTIONALLY_ENCLOSED_BY='"' EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE'
+        """)
+
+        # reference a single file within the stage and a named file format
+        dcur.execute(f"""
+            COPY INTO table1
+            FROM @stage3/{temp_file_basename}.gz
+            FILE_FORMAT = (FORMAT_NAME = 'my_csv_format')
+            ON_ERROR = 'ABORT_STATEMENT'
+        """)
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["file"] == f"stage3/{temp_file_basename}.gz"
+        assert results[0]["status"] == "LOADED"
+        assert results[0]["rows_loaded"] == 2
+
+        dcur.execute("SELECT * FROM table1")
+        assert dcur.fetchall() == [{"A": 1, "B": 2}, {"A": None, "B": 4}]
+
+
+def test_copy_format_name_does_not_exist(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    create_table(dcur)
+    dcur.execute("CREATE STAGE stage3")
+
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+        dcur.execute("COPY INTO table1 FROM @stage3 FILE_FORMAT = (FORMAT_NAME = 'unknown_format')")
+
+    assert str(excinfo.value) == (
+        "002003 (02000): SQL compilation error:\nFile format 'UNKNOWN_FORMAT' does not exist or not authorized."
+    )
 
 
 @patch("fakesnow.copy_into.logger.log_sql", side_effect=logger.log_sql)
@@ -793,6 +838,45 @@ def test_load_history_is_per_table(dcur: snowflake.connector.cursor.DictCursor, 
     dcur.execute("CREATE OR REPLACE TABLE schema1.table1 (a INT, b INT)")
     dcur.execute(sql.format(table="table1", bucket=bucket))
     assert dcur.fetchall()[0]["status"] == "LOADED"
+
+
+def test_params_csv_options():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1 FIELD_OPTIONALLY_ENCLOSED_BY='"'
+        EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE' COMPRESSION='GZIP')
+    ON_ERROR = 'ABORT_STATEMENT'
+    """)
+
+    assert params.file_format == ReadCSV(skip_header=1, quote='"', delimiter=",", null_if=[""], compression="gzip")
+    assert params.on_error == "ABORT_STATEMENT"
+
+    assert (
+        params.file_format.read_expression("s3://mybucket/data/file1.csv").sql(dialect="duckdb")
+        == "READ_CSV('s3://mybucket/data/file1.csv', header = FALSE, skip = 1, quote = '\"', nullstr = [''], compression = 'gzip')"
+    )
+
+
+def test_params_csv_null_if_multiple():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' NULL_IF=('NULL', 'null'))
+    """)
+
+    # EMPTY_FIELD_AS_NULL defaults to TRUE, so '' is included
+    assert params.file_format == ReadCSV(null_if=["", "NULL", "null"])
+
+
+def test_params_csv_empty_field_as_null_false():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' EMPTY_FIELD_AS_NULL=FALSE)
+    """)
+
+    assert params.file_format == ReadCSV(null_if=[])
 
 
 def test__strip_json_extract():

--- a/tests/test_file_format.py
+++ b/tests/test_file_format.py
@@ -1,0 +1,35 @@
+import pytest
+import snowflake.connector.cursor
+
+
+def test_create_file_format(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+        dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV'")
+
+    assert str(excinfo.value) == "002002 (42710): SQL compilation error:\nObject 'MY_FMT' already exists."
+
+
+def test_create_file_format_or_replace(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV'")
+
+    dcur.execute("CREATE OR REPLACE FILE FORMAT my_fmt TYPE='CSV' SKIP_HEADER=1")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+
+def test_create_file_format_if_not_exists(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT IF NOT EXISTS my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+    dcur.execute("CREATE FILE FORMAT IF NOT EXISTS my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "MY_FMT already exists, statement succeeded."}]
+
+
+def test_create_file_format_fully_qualified(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE DATABASE db2")
+    dcur.execute("CREATE SCHEMA db2.schema2")
+
+    dcur.execute("CREATE FILE FORMAT db2.schema2.my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -106,6 +106,29 @@ def test_create_stage(dcur: snowflake.connector.cursor.SnowflakeCursor):
     ]
 
 
+def test_create_stage_or_replace(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE STAGE stage1")
+
+    dcur.execute("CREATE OR REPLACE STAGE stage1 URL='s3://bucket/path/'")
+    assert dcur.fetchall() == [{"status": "Stage area STAGE1 successfully created."}]
+
+    dcur.execute("SHOW STAGES")
+    rows = dcur.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["url"] == "s3://bucket/path/"
+
+
+def test_create_stage_if_not_exists(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE STAGE IF NOT EXISTS stage1")
+    assert dcur.fetchall() == [{"status": "Stage area STAGE1 successfully created."}]
+
+    dcur.execute("CREATE STAGE IF NOT EXISTS stage1")
+    assert dcur.fetchall() == [{"status": "STAGE1 already exists, statement succeeded."}]
+
+    dcur.execute("SHOW STAGES")
+    assert len(dcur.fetchall()) == 1
+
+
 def test_create_stage_qmark_quoted(_fakesnow: None):
     with (
         snowflake.connector.connect(database="db1", schema="schema1", paramstyle="qmark") as conn,


### PR DESCRIPTION
Note: #413 is stacked on this branch — please merge this one first.

- **Stages**: `_fs_stages` gains a primary key so OR REPLACE maps to duckdb `INSERT OR REPLACE`; OR REPLACE also empties the stage's backing storage, as in Snowflake; IF NOT EXISTS returns "already exists, statement succeeded." instead of erroring.
- **Named file formats**: stored (with their options as JSON) in a new `_fs_global._fs_information_schema._fs_file_formats` table; the FILE FORMAT kind is accepted in checks.py instead of asserting (which returned HTTP 500 in server mode); OR REPLACE and IF NOT EXISTS supported.
- **COPY INTO**: `FILE_FORMAT = (FORMAT_NAME = ...)` resolves stored formats; `SKIP_HEADER > 1`, `NULL_IF`, `EMPTY_FIELD_AS_NULL`, `ESCAPE_UNENCLOSED_FIELD='NONE'` and `COMPRESSION` map onto duckdb's `read_csv` (combinations with no faithful duckdb mapping raise NotImplementedError); `ON_ERROR` accepts a string literal; a stage reference can include a path suffix, eg: `@stage1/file.csv.gz` (prefix match, as in Snowflake).

Fixes #408. Split out of #400 per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

