### PR TITLE
feat: PUT over http in server mode, unquoted PUT urls, PUT options, and table stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ Partially supported:
 - Tags
 - User management
 - Stages and PUT
+- Named file formats
 - `COPY INTO` from S3 sources and stages, see [COPY INTO](#copy-into)
 
 Not yet implemented:

--- a/fakesnow/checks.py
+++ b/fakesnow/checks.py
@@ -84,8 +84,8 @@ def _missing_qualifiers(node: exp.Table) -> tuple[bool, bool]:
             # "CREATE/DROP SCHEMA"
             no_database = not node.args.get("catalog")
             no_schema = False
-        elif parent_kind.upper() in {"TABLE", "VIEW", "STAGE", "TAG", "SEQUENCE"}:
-            # "CREATE/DROP TABLE/VIEW/STAGE/TAG"
+        elif parent_kind.upper() in {"TABLE", "VIEW", "STAGE", "TAG", "SEQUENCE", "FILE FORMAT"}:
+            # "CREATE/DROP TABLE/VIEW/STAGE/TAG/FILE FORMAT"
             no_database = not node.args.get("catalog")
             no_schema = not node.args.get("db")
         else:

--- a/fakesnow/copy_into.py
+++ b/fakesnow/copy_into.py
@@ -17,6 +17,7 @@ from sqlglot import Expr, exp
 import fakesnow.transforms.stage as stage
 from fakesnow import logger
 from fakesnow.params import MutableParams, pop_qmark_param
+from fakesnow.transforms.file_format import format_options, lookup_file_format
 
 Params = Sequence[Any] | dict[Any, Any]
 
@@ -46,7 +47,9 @@ def copy_into(
     expr: exp.Copy,
     params: MutableParams | None = None,
 ) -> str:
-    cparams = _params(expr, params)
+    cparams = _params(
+        expr, params, duck_conn=duck_conn, current_database=current_database, current_schema=current_schema
+    )
 
     from_source = _from_source(expr)
     source = (
@@ -206,7 +209,13 @@ def _get_table_columns(
     return [col[0].upper() for col in columns]
 
 
-def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
+def _params(
+    expr: exp.Copy,
+    params: MutableParams | None = None,
+    duck_conn: DuckDBPyConnection | None = None,
+    current_database: str | None = None,
+    current_schema: str | None = None,
+) -> CopyParams:
     kwargs = {}
     force = False
     purge = False
@@ -220,12 +229,16 @@ def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
             if kwargs.get("file_format"):
                 raise ValueError(cparams)
 
-            var_type = next((e.args["value"].this for e in param.expressions if e.this.this == "TYPE"), None)
-            if not var_type:
-                raise NotImplementedError("FILE_FORMAT without TYPE is not currently implemented")
+            options = format_options(list(param.expressions))
+            if format_name := options.pop("FORMAT_NAME", None):
+                if options.get("TYPE"):
+                    raise ValueError("Cannot specify both FORMAT_NAME and TYPE in FILE_FORMAT")
+                assert duck_conn, "duck_conn is required to resolve FORMAT_NAME"
+                options = lookup_file_format(duck_conn, str(format_name), current_database, current_schema)
 
+            var_type = str(options.get("TYPE", "CSV")).upper()
             if var_type == "CSV":
-                kwargs["file_format"] = handle_csv(param.expressions)
+                kwargs["file_format"] = handle_csv(options)
             elif var_type == "PARQUET":
                 kwargs["file_format"] = ReadParquet()
             else:
@@ -237,7 +250,7 @@ def _params(expr: exp.Copy, params: MutableParams | None = None) -> CopyParams:
         elif var == "PURGE":
             purge = True
         elif var == "ON_ERROR":
-            if isinstance(param.expression, exp.Var):
+            if isinstance(param.expression, (exp.Var, exp.Literal)):
                 on_error = param.expression.name.upper()
             elif isinstance(param.expression, exp.Placeholder):
                 on_error = pop_qmark_param(params, expr, param.expression)
@@ -296,7 +309,9 @@ def _from_source(expr: exp.Copy) -> str:
 def stage_url_from_var(
     var: str, duck_conn: DuckDBPyConnection, current_database: str | None, current_schema: str | None
 ) -> str:
-    database_name, schema_name, name = stage.parts_from_var(var, current_database, current_schema)
+    # a stage reference can include a path suffix, eg: @stage1/dir/file.csv.gz
+    stage_var, _, path = var.partition("/")
+    database_name, schema_name, name = stage.parts_from_var(stage_var, current_database, current_schema)
 
     # Look up the stage URL
     duck_conn.execute(
@@ -308,7 +323,8 @@ def stage_url_from_var(
     )
     if result := duck_conn.fetchone():
         # if no URL is found, it is an internal stage ie: local directory
-        return result[0] or stage.internal_dir(f"{database_name}.{schema_name}.{name}")
+        url = result[0] or stage.internal_dir(f"{database_name}.{schema_name}.{name}")
+        return f"{url.rstrip('/')}/{path}" if path else url
     else:
         raise snowflake.connector.errors.ProgrammingError(
             msg=f"SQL compilation error:\nStage '{database_name}.{schema_name}.{name}' does not exist or not authorized.",  # noqa: E501
@@ -331,11 +347,13 @@ def _source_urls(source: str, files: list[str]) -> list[str]:
 
 def _source_glob(source: str, duck_conn: DuckDBPyConnection) -> list[str]:
     """List files from the source using duckdb glob."""
+    is_internal_file = stage.is_internal(source) and not os.path.isdir(source)
     if stage.is_internal(source):
         source = Path(source).as_uri()  # convert local directory to a file URL
 
     scheme, _netloc, _path, _params, _query, _fragment = urlparse(source)
-    glob = f"{source}/*" if scheme == "file" else f"{source}*"
+    # a stage path suffix is a prefix match, eg: @stage1/dir/file matches dir/file*
+    glob = f"{source}/*" if scheme == "file" and not is_internal_file else f"{source}*"
     sql = f"SELECT file FROM glob('{glob}')"
     logger.log_sql(sql)
     result = duck_conn.execute(sql).fetchall()
@@ -514,29 +532,57 @@ def _strip_json_extract(expr: exp.Select) -> exp.Select:
     return expr
 
 
-def handle_csv(expressions: list[exp.Property]) -> ReadCSV:
+def handle_csv(options: dict[str, Any]) -> ReadCSV:
     skip_header = ReadCSV.skip_header
     quote = ReadCSV.quote
     delimiter = ReadCSV.delimiter
+    null_if: list[str] | None = None
+    compression: str | None = None
+    empty_field_as_null = True
 
-    for expression in expressions:
-        exp_type = expression.name
-        if exp_type in {"TYPE"}:
+    for name, value in options.items():
+        if name == "TYPE":
             continue
 
-        elif exp_type == "SKIP_HEADER":
-            skip_header = True
-        elif exp_type == "FIELD_OPTIONALLY_ENCLOSED_BY":
-            quote = expression.args["value"].this
-        elif exp_type == "FIELD_DELIMITER":
-            delimiter = expression.args["value"].this
+        elif name == "SKIP_HEADER":
+            skip_header = int(value)
+        elif name == "FIELD_OPTIONALLY_ENCLOSED_BY":
+            quote = str(value)
+        elif name == "FIELD_DELIMITER":
+            delimiter = str(value)
+        elif name == "NULL_IF":
+            null_if = [str(v) for v in value] if isinstance(value, list) else [str(value)]
+        elif name == "EMPTY_FIELD_AS_NULL":
+            empty_field_as_null = bool(value)
+        elif name == "ESCAPE_UNENCLOSED_FIELD":
+            # duckdb does not escape unenclosed fields, which matches ESCAPE_UNENCLOSED_FIELD = NONE
+            if str(value).upper() != "NONE":
+                raise NotImplementedError(f"ESCAPE_UNENCLOSED_FIELD = {value} is not currently implemented")
+        elif name == "COMPRESSION":
+            comp = str(value).upper()
+            if comp in {"GZIP", "NONE"}:
+                compression = comp.lower()
+            elif comp not in {"AUTO", "AUTO_DETECT"}:
+                # AUTO matches duckdb's default of detecting compression from the file extension
+                raise NotImplementedError(f"COMPRESSION = {value} is not currently implemented")
         else:
-            raise NotImplementedError(f"{exp_type} is not currently implemented")
+            raise NotImplementedError(f"{name} is not currently implemented")
+
+    # empty fields are null by default in duckdb (nullstr = ''), matching EMPTY_FIELD_AS_NULL = TRUE
+    if empty_field_as_null:
+        if null_if is not None and "" not in null_if:
+            null_if = ["", *null_if]
+    elif null_if is None:
+        null_if = []
+    elif "" in null_if:
+        raise NotImplementedError("EMPTY_FIELD_AS_NULL = FALSE with NULL_IF containing '' is not currently implemented")
 
     return ReadCSV(
         skip_header=skip_header,
         quote=quote,
         delimiter=delimiter,
+        null_if=null_if,
+        compression=compression,
     )
 
 
@@ -558,16 +604,18 @@ class FileTypeHandler(Protocol):
 
 @dataclass
 class ReadCSV(FileTypeHandler):
-    skip_header: bool = False
+    skip_header: int = 0
     quote: str | None = None
     delimiter: str = ","
+    null_if: list[str] | None = None
+    compression: str | None = None
 
     def read_expression(self, url: str) -> Expr:
         # don't parse header and use as column names, keep them as column0, column1, etc
         args = [self.make_eq("header", False)]
 
         if self.skip_header:
-            args.append(self.make_eq("skip", 1))
+            args.append(self.make_eq("skip", self.skip_header))
 
         if self.quote:
             quote = self.quote.replace("'", "''")
@@ -576,6 +624,12 @@ class ReadCSV(FileTypeHandler):
         if self.delimiter and self.delimiter != ",":
             delimiter = self.delimiter.replace("'", "''")
             args.append(self.make_eq("sep", delimiter))
+
+        if self.null_if is not None:
+            args.append(self.make_eq("nullstr", [v.replace("'", "''") for v in self.null_if]))
+
+        if self.compression:
+            args.append(self.make_eq("compression", self.compression))
 
         return exp.func("read_csv", exp.Literal(this=url, is_string=True), *args)
 

--- a/fakesnow/copy_into.py
+++ b/fakesnow/copy_into.py
@@ -5,7 +5,6 @@ import os
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from enum import Enum
-from pathlib import Path
 from typing import Any, NamedTuple, Protocol, cast
 from urllib.parse import urlparse, urlunparse
 
@@ -313,6 +312,11 @@ def stage_url_from_var(
     stage_var, _, path = var.partition("/")
     database_name, schema_name, name = stage.parts_from_var(stage_var, current_database, current_schema)
 
+    if name.startswith("%"):
+        # a table stage exists implicitly for every table
+        url = stage.internal_dir(f"{database_name}.{schema_name}.{name}")
+        return f"{url.rstrip('/')}/{path}" if path else url
+
     # Look up the stage URL
     duck_conn.execute(
         """
@@ -347,13 +351,13 @@ def _source_urls(source: str, files: list[str]) -> list[str]:
 
 def _source_glob(source: str, duck_conn: DuckDBPyConnection) -> list[str]:
     """List files from the source using duckdb glob."""
-    is_internal_file = stage.is_internal(source) and not os.path.isdir(source)
     if stage.is_internal(source):
-        source = Path(source).as_uri()  # convert local directory to a file URL
-
-    scheme, _netloc, _path, _params, _query, _fragment = urlparse(source)
-    # a stage path suffix is a prefix match, eg: @stage1/dir/file matches dir/file*
-    glob = f"{source}/*" if scheme == "file" and not is_internal_file else f"{source}*"
+        # keep the plain path: duckdb does not decode percent-encoded file URIs
+        # a stage path suffix is a prefix match, eg: @stage1/dir/file matches dir/file*
+        glob = f"{source.rstrip('/')}/*" if os.path.isdir(source) else f"{source}*"
+    else:
+        scheme, _netloc, _path, _params, _query, _fragment = urlparse(source)
+        glob = f"{source}/*" if scheme == "file" else f"{source}*"
     sql = f"SELECT file FROM glob('{glob}')"
     logger.log_sql(sql)
     result = duck_conn.execute(sql).fetchall()

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -54,6 +54,7 @@ SQL_CREATED_TABLE = Template("SELECT 'Table ${name} successfully created.' as 's
 SQL_CREATED_VIEW = Template("SELECT 'View ${name} successfully created.' as 'status'")
 SQL_CREATED_STAGE = Template("SELECT 'Stage area ${name} successfully created.' as status")
 SQL_OBJECT_EXISTS = Template("SELECT '${name} already exists, statement succeeded.' as status")
+SQL_CREATED_FILE_FORMAT = Template("SELECT 'File format ${name} successfully created.' as status")
 SQL_DROPPED = Template("SELECT '${name} successfully dropped.' as 'status'")
 SQL_INSERTED_ROWS = Template("SELECT ${count} as 'number of rows inserted'")
 SQL_UPDATED_ROWS = Template("SELECT ${count} as 'number of rows updated', 0 as 'number of multi-joined rows updated'")
@@ -370,6 +371,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.alter_table_strip_cluster_by)
             .transform(transforms.numeric_agg_implicit_cast)
             .transform(lambda e: transforms.create_stage(e, self._conn.database, self._conn.schema))
+            .transform(lambda e: transforms.create_file_format(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.list_stage(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.put_stage(e, self._conn.database, self._conn.schema, params))
             .transform(lambda e: transforms.create_table_as(e, self._duck_conn))
@@ -443,8 +445,10 @@ class FakeSnowflakeCursor:
             # see https://docs.snowflake.com/en/sql-reference/transactions#ddl
             # and https://docs.snowflake.com/en/sql-reference/sql-ddl-summary
             # TODO: include DESCRIBE, SHOW, USE in this list of DDL statements
-            if isinstance(transformed, (exp.Alter, exp.Comment, exp.Create, exp.Drop)) or transformed.args.get(
-                "create_stage_name"
+            if (
+                isinstance(transformed, (exp.Alter, exp.Comment, exp.Create, exp.Drop))
+                or transformed.args.get("create_stage_name")
+                or transformed.args.get("create_file_format_name")
             ):
                 self._duck_conn.commit()
                 self._conn._in_transaction = False
@@ -455,6 +459,7 @@ class FakeSnowflakeCursor:
             elif (
                 isinstance(transformed, (exp.Insert, exp.Update, exp.Delete, exp.Merge, exp.Copy))
                 and not transformed.args.get("create_stage_name")
+                and not transformed.args.get("create_file_format_name")
                 and not self._conn._in_transaction
             ):
                 self._duck_conn.begin()
@@ -529,6 +534,19 @@ class FakeSnowflakeCursor:
             else:
                 raise snowflake.connector.errors.ProgrammingError(
                     msg=f"SQL compilation error:\nObject '{stage_name}' already exists.",
+                    errno=2002,
+                    sqlstate="42710",
+                )
+
+        elif format_name := transformed.args.get("create_file_format_name"):
+            (affected_count,) = self._duck_conn.fetchall()[0]
+            if affected_count > 0:
+                result_sql = SQL_CREATED_FILE_FORMAT.substitute(name=format_name)
+            elif transformed.args.get("create_file_format_if_not_exists"):
+                result_sql = SQL_OBJECT_EXISTS.substitute(name=format_name)
+            else:
+                raise snowflake.connector.errors.ProgrammingError(
+                    msg=f"SQL compilation error:\nObject '{format_name}' already exists.",
                     errno=2002,
                     sqlstate="42710",
                 )

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -207,6 +207,7 @@ class FakeSnowflakeCursor:
                 print(f"{command};params={p}" if p else f"{command};", file=sys.stderr)
 
             command = self._inline_variables(command)
+            command = stage.normalise_put_src(command)
             if kwargs.get("binding_params"):
                 # params have come via the server
                 params = kwargs["binding_params"]

--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -53,6 +53,7 @@ SQL_CREATED_SECRET = Template("SELECT 'Secret ${name} successfully created.' as 
 SQL_CREATED_TABLE = Template("SELECT 'Table ${name} successfully created.' as 'status'")
 SQL_CREATED_VIEW = Template("SELECT 'View ${name} successfully created.' as 'status'")
 SQL_CREATED_STAGE = Template("SELECT 'Stage area ${name} successfully created.' as status")
+SQL_OBJECT_EXISTS = Template("SELECT '${name} already exists, statement succeeded.' as status")
 SQL_DROPPED = Template("SELECT '${name} successfully dropped.' as 'status'")
 SQL_INSERTED_ROWS = Template("SELECT ${count} as 'number of rows inserted'")
 SQL_UPDATED_ROWS = Template("SELECT ${count} as 'number of rows updated', 0 as 'number of multi-joined rows updated'")
@@ -521,13 +522,16 @@ class FakeSnowflakeCursor:
 
         elif stage_name := transformed.args.get("create_stage_name"):
             (affected_count,) = self._duck_conn.fetchall()[0]
-            if affected_count == 0:
+            if affected_count > 0:
+                result_sql = SQL_CREATED_STAGE.substitute(name=stage_name)
+            elif transformed.args.get("create_stage_if_not_exists"):
+                result_sql = SQL_OBJECT_EXISTS.substitute(name=stage_name)
+            else:
                 raise snowflake.connector.errors.ProgrammingError(
                     msg=f"SQL compilation error:\nObject '{stage_name}' already exists.",
                     errno=2002,
                     sqlstate="42710",
                 )
-            result_sql = SQL_CREATED_STAGE.substitute(name=stage_name)
 
         elif stage_name := transformed.args.get("list_stage_name") or transformed.args.get("put_stage_name"):
             if self._duck_conn.to_arrow_table().num_rows != 1:

--- a/fakesnow/info_schema.py
+++ b/fakesnow/info_schema.py
@@ -255,7 +255,8 @@ CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_stages (
     storage_integration TEXT,
     endpoint TEXT,
     owner_role_type TEXT,
-    directory_enabled TEXT
+    directory_enabled TEXT,
+    PRIMARY KEY (database_name, schema_name, name)
 );
 """
 

--- a/fakesnow/info_schema.py
+++ b/fakesnow/info_schema.py
@@ -260,6 +260,18 @@ CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_stages (
 );
 """
 
+SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_FILE_FORMATS_TABLE = """
+CREATE TABLE IF NOT EXISTS _fs_global._fs_information_schema._fs_file_formats (
+    created_on TIMESTAMPTZ,
+    name TEXT,
+    database_name TEXT,
+    schema_name TEXT,
+    type TEXT,
+    options TEXT,
+    PRIMARY KEY (database_name, schema_name, name)
+);
+"""
+
 
 def per_db_creation_sql(catalog: str) -> str:
     return f"""
@@ -279,7 +291,8 @@ def fs_global_creation_sql() -> str:
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_COLUMNS_EXT};
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_COLUMNS_VIEW};
         {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_USERS_TABLE};
-        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_STAGES_TABLE}
+        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_STAGES_TABLE};
+        {SQL_CREATE_GLOBAL_INFORMATION_SCHEMA_FILE_FORMATS_TABLE}
     """
 
 

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -3,17 +3,19 @@ from __future__ import annotations
 import gzip
 import json
 import logging
+import os
 import secrets
 from base64 import b64encode
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import quote
 
 import snowflake.connector.errors
 from sqlglot import Expr, exp, parse_one
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
 from starlette.routing import Route
 
 from fakesnow import statement_type
@@ -146,6 +148,15 @@ async def query_request(request: Request) -> JSONResponse:
             expr = cur._last_transformed  # noqa: SLF001
             assert expr
             if put_stage_data := expr.args.get("put_stage_data"):
+                if not expr.args.get("put_stage_target_from_params"):
+                    # rewrite the stage info so the client uploads the file over http to this
+                    # server, rather than writing to a local path, which fails when the client
+                    # doesn't share the server's filesystem (eg: the server runs in a container).
+                    # GCS is the only location type the connector uploads to via a plain http
+                    # presigned url, so mimic it. a PUT with a ? placeholder target keeps
+                    # LOCAL_FS because the connector re-requests the presigned url by executing
+                    # the command without bindings (see SnowflakeGCSRestClient).
+                    put_stage_data["stageInfo"] = gcs_stage_info(request, expr, put_stage_data)
                 # this is a PUT command, so return the stage data
                 return JSONResponse(
                     {
@@ -220,6 +231,51 @@ async def query_request(request: Request) -> JSONResponse:
             {"data": None, "code": e.code, "message": e.message, "success": False, "headers": None},
             status_code=e.status_code,
         )
+
+
+def gcs_stage_info(request: Request, expr: Expr, put_stage_data: stage.UploadCommandDict) -> dict[str, Any]:
+    """Stage info that uploads to this server over http via a GCS-style presigned url.
+
+    The presigned url targets the file's destination name. The connector re-requests it
+    with the destination file name as the source, so the url is correct for the actual
+    upload even when auto compression renames the file.
+    """
+    fqname = expr.args["put_stage_name"]
+    src = put_stage_data["src_locations"][0]
+    dst = os.path.basename(src)
+    if put_stage_data["autoCompress"] and not dst.endswith(".gz"):
+        dst += ".gz"
+
+    catalog, schema, name = fqname.split(".")
+    path = quote(f"{catalog}/{schema}/{name}/{dst}")
+    return {
+        "locationType": "GCS",
+        "location": f"{fqname}/",
+        "creds": {},
+        "presignedUrl": f"{request.url.scheme}://{request.url.netloc}/fs_bucket/{path}",
+    }
+
+
+def _write_bucket_file(path: str, body: bytes) -> str | None:
+    """Write body to path within the local bucket, returning the target path, or None if invalid."""
+    target = os.path.normpath(os.path.join(stage.LOCAL_BUCKET_PATH, path))
+    if not target.startswith(stage.LOCAL_BUCKET_PATH + os.sep):
+        return None
+
+    os.makedirs(os.path.dirname(target), exist_ok=True)
+    with open(target, "wb") as f:
+        f.write(body)
+    return target
+
+
+async def bucket_upload(request: Request) -> Response:
+    """Store an uploaded file in the local bucket, ie: the backing storage for internal stages."""
+    body = await request.body()
+    target = await run_in_threadpool(_write_bucket_file, request.path_params["path"], body)
+    if not target:
+        return Response(status_code=400)
+    logger.info(f"Uploaded {len(body)} bytes to {target}")
+    return Response()
 
 
 def describe_only_response(
@@ -315,6 +371,7 @@ routes = [
         methods=["POST"],
     ),
     Route("/queries/v1/abort-request", lambda _: JSONResponse({"success": True}), methods=["POST"]),
+    Route("/fs_bucket/{path:path}", bucket_upload, methods=["PUT"]),
     Route("/monitoring/queries/{sfqid}", monitoring_query, methods=["GET"]),
 ]
 

--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -25,6 +25,7 @@ from fakesnow.fakes import FakeSnowflakeConnection
 from fakesnow.instance import FakeSnow
 from fakesnow.rowtype import ColumnInfo, describe_as_rowtype
 from fakesnow.statement_type import DML_TYPE_IDS, statement_type_id
+from fakesnow.transforms import stage
 
 logger = logging.getLogger("fakesnow.server")
 # use same format as uvicorn
@@ -94,7 +95,7 @@ async def query_request(request: Request) -> JSONResponse:
 
         body_json = json.loads(body)
 
-        sql_text = body_json["sqlText"]
+        sql_text = stage.normalise_put_src(body_json["sqlText"])
 
         params: Any = None
         # rows of params, when the client sends an array binding

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -5,6 +5,9 @@ from fakesnow.transforms.ddl import (
     alter_table_strip_cluster_by as alter_table_strip_cluster_by,
     create_table_autoincrement as create_table_autoincrement,
 )
+from fakesnow.transforms.file_format import (
+    create_file_format as create_file_format,
+)
 from fakesnow.transforms.merge import merge as merge
 from fakesnow.transforms.show import (
     show_columns as show_columns,

--- a/fakesnow/transforms/file_format.py
+++ b/fakesnow/transforms/file_format.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import datetime
+import json
+from typing import Any
+
+import snowflake.connector.errors
+import sqlglot
+from duckdb import DuckDBPyConnection
+from sqlglot import Expr, exp
+
+from fakesnow.transforms.stage import parts_from_var
+
+
+def option_value(value: Expr | None) -> Any:  # noqa: ANN401
+    """Convert a file format option value expression to a python value."""
+    if isinstance(value, exp.Literal):
+        return value.this if value.is_string else int(value.this)
+    if isinstance(value, exp.Boolean):
+        return value.this
+    if isinstance(value, exp.Paren):
+        return [option_value(value.this)]
+    if isinstance(value, exp.Tuple):
+        return [option_value(e) for e in value.expressions]
+    if isinstance(value, exp.Var):
+        return value.this
+    raise NotImplementedError(f"{value.__class__.__name__} as a file format option value")
+
+
+def format_options(properties: list[Expr]) -> dict[str, Any]:
+    """Convert file format properties to a dict of option name -> python value."""
+    options: dict[str, Any] = {}
+    for prop in properties:
+        if isinstance(prop, exp.TemporaryProperty):
+            continue
+        assert isinstance(prop, exp.Property), f"{prop.__class__} is not a Property"
+        assert isinstance(prop.this, exp.Var), f"{prop.this.__class__} is not a Var"
+        options[prop.this.name.upper()] = option_value(prop.args.get("value"))
+    return options
+
+
+def create_file_format(
+    expression: Expr,
+    current_database: str | None,
+    current_schema: str | None,
+) -> Expr:
+    """Transform CREATE FILE FORMAT to an INSERT statement for the fake file formats table."""
+    if not (
+        isinstance(expression, exp.Create)
+        and (kind := expression.args.get("kind"))
+        and isinstance(kind, str)
+        and kind.upper() == "FILE FORMAT"
+        and (table := expression.find(exp.Table))
+    ):
+        return expression
+
+    ident = table.this
+    if not isinstance(ident, exp.Identifier):
+        raise snowflake.connector.errors.ProgrammingError(
+            msg=f"SQL compilation error:\nInvalid identifier type {ident.__class__.__name__} for file format name.",
+            errno=1003,
+            sqlstate="42000",
+        )
+
+    catalog = table.catalog or current_database
+    schema = table.db or current_schema
+    format_name = ident.this
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+    replace = expression.args.get("replace")
+    if_not_exists = expression.args.get("exists")
+
+    properties = expression.args.get("properties") or []
+    options = format_options(list(properties))
+    format_type = str(options.get("TYPE", "CSV")).upper()
+    options_json = json.dumps(options).replace("'", "''")
+
+    guard = (
+        ""
+        if replace
+        else f"""
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _fs_global._fs_information_schema._fs_file_formats
+            WHERE name = '{format_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
+        )"""
+    )
+    insert_sql = f"""
+        INSERT {"OR REPLACE" if replace else ""} INTO _fs_global._fs_information_schema._fs_file_formats
+        (created_on, name, database_name, schema_name, type, options)
+        SELECT
+            '{now}', '{format_name}', '{catalog}', '{schema}', '{format_type}', '{options_json}'
+        {guard}
+        """
+    transformed = sqlglot.parse_one(insert_sql, read="duckdb")
+    transformed.args["create_file_format_name"] = format_name
+    transformed.args["create_file_format_if_not_exists"] = if_not_exists
+    return transformed
+
+
+def lookup_file_format(
+    duck_conn: DuckDBPyConnection,
+    name: str,
+    current_database: str | None,
+    current_schema: str | None,
+) -> dict[str, Any]:
+    """Return the stored options of a named file format.
+
+    Raises if the file format does not exist.
+    """
+    database_name, schema_name, format_name = parts_from_var(name, current_database, current_schema)
+
+    duck_conn.execute(
+        """
+        SELECT options FROM _fs_global._fs_information_schema._fs_file_formats
+        WHERE database_name = ? AND schema_name = ? AND name = ?
+        """,
+        (database_name, schema_name, format_name),
+    )
+    if result := duck_conn.fetchone():
+        return json.loads(result[0])
+
+    raise snowflake.connector.errors.ProgrammingError(
+        msg=f"SQL compilation error:\nFile format '{format_name}' does not exist or not authorized.",
+        errno=2003,
+        sqlstate="02000",
+    )

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -188,12 +188,15 @@ def put_stage(
 
     assert isinstance(expression.this, exp.Literal), "PUT command requires a file path as a literal"
     src_url = urlparse(expression.this.this)
-    src_path = url2pathname(src_url.path)
+    # include netloc to handle relative urls, eg: file://data.csv.gz as sent by the connector
+    # when it re-requests a presigned url using the destination file name
+    src_path = src_url.netloc + url2pathname(src_url.path)
     target = expression.args["target"]
 
     assert isinstance(target, exp.Var), f"{target} is not a exp.Var"
     this = target.text("this")
-    if this == "?":
+    target_from_params = this == "?"
+    if target_from_params:
         if not (isinstance(params, list) and len(params) == 1):
             raise NotImplementedError("PUT requires a single parameter for the stage name")
         this = params.pop(0)
@@ -213,6 +216,7 @@ def put_stage(
     transformed = sqlglot.parse_one(stage_lookup_sql(catalog, schema, stage_name), read="duckdb")
     fqname = f"{catalog}.{schema}.{stage_name}"
     transformed.args["put_stage_name"] = fqname
+    transformed.args["put_stage_target_from_params"] = target_from_params
     transformed.args["put_stage_data"] = {
         "stageInfo": {
             # use LOCAL_FS otherwise we need to mock S3 with HTTPS which requires a certificate

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -139,13 +139,7 @@ def list_stage(expression: Expr, current_database: str | None, current_schema: s
     var = stage.text("this")
     catalog, schema, stage_name = parts_from_var(var, current_database=current_database, current_schema=current_schema)
 
-    query = f"""
-        SELECT *
-        from _fs_global._fs_information_schema._fs_stages
-        where database_name = '{catalog}' and schema_name = '{schema}' and name = '{stage_name}'
-    """
-
-    transformed = sqlglot.parse_one(query, read="duckdb")
+    transformed = sqlglot.parse_one(stage_lookup_sql(catalog, schema, stage_name), read="duckdb")
     transformed.args["list_stage_name"] = f"{catalog}.{schema}.{stage_name}"
     return transformed
 
@@ -185,13 +179,7 @@ def put_stage(
     var = this[1:]
     catalog, schema, stage_name = parts_from_var(var, current_database=current_database, current_schema=current_schema)
 
-    query = f"""
-        SELECT *
-        from _fs_global._fs_information_schema._fs_stages
-        where database_name = '{catalog}' and schema_name = '{schema}' and name = '{stage_name}'
-    """
-
-    transformed = sqlglot.parse_one(query, read="duckdb")
+    transformed = sqlglot.parse_one(stage_lookup_sql(catalog, schema, stage_name), read="duckdb")
     fqname = f"{catalog}.{schema}.{stage_name}"
     transformed.args["put_stage_name"] = fqname
     transformed.args["put_stage_data"] = {
@@ -211,6 +199,24 @@ def put_stage(
     }
 
     return transformed
+
+
+def stage_lookup_sql(catalog: str, schema: str, stage_name: str) -> str:
+    """SQL that returns a single row when the stage exists.
+
+    A stage name starting with % is a table stage, which exists implicitly for every table.
+    """
+    if stage_name.startswith("%"):
+        return f"""
+            SELECT *
+            from duckdb_tables()
+            where database_name = '{catalog}' and schema_name = '{schema}' and table_name = '{stage_name[1:]}'
+        """
+    return f"""
+        SELECT *
+        from _fs_global._fs_information_schema._fs_stages
+        where database_name = '{catalog}' and schema_name = '{schema}' and name = '{stage_name}'
+    """
 
 
 def parts_from_var(var: str, current_database: str | None, current_schema: str | None) -> tuple[str, str, str]:

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import re
 import shutil
 import tempfile
 from pathlib import PurePath
@@ -144,6 +145,34 @@ def list_stage(expression: Expr, current_database: str | None, current_schema: s
     return transformed
 
 
+_PUT_UNQUOTED_SRC = re.compile(r"^(\s*PUT\s+)(file://\S+)", re.IGNORECASE)
+
+
+def normalise_put_src(command: str) -> str:
+    """Quote an unquoted PUT source so sqlglot parses PUT as exp.Put rather than exp.Command."""
+    return _PUT_UNQUOTED_SRC.sub(r"\1'\2'", command)
+
+
+def put_options(expression: exp.Put) -> dict[str, Any]:
+    """Extract PUT options as a dict of option name -> python value."""
+    options: dict[str, Any] = {}
+    properties = expression.args.get("properties") or []
+    for prop in properties:
+        assert isinstance(prop, exp.Property), f"{prop.__class__} is not a Property"
+        assert isinstance(prop.this, exp.Var), f"{prop.this.__class__} is not a Var"
+        name = prop.this.name.upper()
+        value = prop.args.get("value")
+        if isinstance(value, exp.Boolean):
+            options[name] = value.this
+        elif isinstance(value, exp.Literal):
+            options[name] = value.this if value.is_string else int(value.this)
+        elif isinstance(value, exp.Var):
+            options[name] = value.this
+        else:
+            raise NotImplementedError(f"PUT option {name} with value {value}")
+    return options
+
+
 def put_stage(
     expression: Expr,
     current_database: str | None,
@@ -179,6 +208,8 @@ def put_stage(
     var = this[1:]
     catalog, schema, stage_name = parts_from_var(var, current_database=current_database, current_schema=current_schema)
 
+    options = put_options(expression)
+
     transformed = sqlglot.parse_one(stage_lookup_sql(catalog, schema, stage_name), read="duckdb")
     fqname = f"{catalog}.{schema}.{stage_name}"
     transformed.args["put_stage_name"] = fqname
@@ -190,11 +221,11 @@ def put_stage(
             "creds": {},
         },
         "src_locations": [src_path],
-        # defaults as per https://docs.snowflake.com/en/sql-reference/sql/put TODO: support other values
-        "parallel": 4,
-        "autoCompress": True,
-        "sourceCompression": "auto_detect",
-        "overwrite": False,
+        # defaults as per https://docs.snowflake.com/en/sql-reference/sql/put
+        "parallel": options.get("PARALLEL", 4),
+        "autoCompress": options.get("AUTO_COMPRESS", True),
+        "sourceCompression": str(options.get("SOURCE_COMPRESSION", "auto_detect")).lower(),
+        "overwrite": options.get("OVERWRITE", False),
         "command": "UPLOAD",
     }
 
@@ -272,18 +303,28 @@ def list_stage_files_sql(stage_name: str) -> str:
 
 
 def upload_files(put_stage_data: UploadCommandDict) -> list[dict[str, Any]]:
+    auto_compress = put_stage_data["autoCompress"]
     results = []
     for src in put_stage_data["src_locations"]:
         basename = os.path.basename(src)
         stage_dir = put_stage_data["stageInfo"]["location"]
 
         os.makedirs(stage_dir, exist_ok=True)
-        gzip_file_name, target_size = SnowflakeFileUtil.compress_file_with_gzip(src, stage_dir)
+        source_is_gzipped = basename.endswith(".gz")
 
-        # Rename to match expected .gz extension on upload
-        target_basename = basename + ".gz"
-        target = os.path.join(stage_dir, target_basename)
-        os.replace(gzip_file_name, target)
+        if auto_compress and not source_is_gzipped:
+            gzip_file_name, _ = SnowflakeFileUtil.compress_file_with_gzip(src, stage_dir)
+
+            # Rename to match expected .gz extension on upload
+            target_basename = basename + ".gz"
+            target = os.path.join(stage_dir, target_basename)
+            os.replace(gzip_file_name, target)
+            target_compression = "GZIP"
+        else:
+            target_basename = basename
+            target = os.path.join(stage_dir, target_basename)
+            shutil.copyfile(src, target)
+            target_compression = "GZIP" if source_is_gzipped else "NONE"
 
         target_size = os.path.getsize(target)
         source_size = os.path.getsize(src)
@@ -294,8 +335,8 @@ def upload_files(put_stage_data: UploadCommandDict) -> list[dict[str, Any]]:
                 "target": target_basename,
                 "source_size": source_size,
                 "target_size": target_size,
-                "source_compression": "NONE",
-                "target_compression": "GZIP",
+                "source_compression": "GZIP" if source_is_gzipped else "NONE",
+                "target_compression": target_compression,
                 "status": "UPLOADED",
                 "message": "",
             }

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import os
+import shutil
 import tempfile
 from pathlib import PurePath
 from typing import Any, TypedDict
@@ -111,6 +112,9 @@ def create_stage(
     transformed = sqlglot.parse_one(insert_sql, read="duckdb")
     transformed.args["create_stage_name"] = stage_name
     transformed.args["create_stage_if_not_exists"] = if_not_exists
+    if replace:
+        # a replaced stage starts empty
+        shutil.rmtree(internal_dir(f"{catalog}.{schema}.{stage_name}"), ignore_errors=True)
     return transformed
 
 

--- a/fakesnow/transforms/stage.py
+++ b/fakesnow/transforms/stage.py
@@ -85,8 +85,20 @@ def create_stage(
 
     stage_type = ("EXTERNAL" if url else "INTERNAL") + (" TEMPORARY" if is_temp else "")
 
+    replace = expression.args.get("replace")
+    if_not_exists = expression.args.get("exists")
+
+    guard = (
+        ""
+        if replace
+        else f"""
+        WHERE NOT EXISTS (
+            SELECT 1 FROM _fs_global._fs_information_schema._fs_stages
+            WHERE name = '{stage_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
+        )"""
+    )
     insert_sql = f"""
-        INSERT INTO _fs_global._fs_information_schema._fs_stages
+        INSERT {"OR REPLACE" if replace else ""} INTO _fs_global._fs_information_schema._fs_stages
         (created_on, name, database_name, schema_name, url, has_credentials, has_encryption_key, owner,
         comment, region, type, cloud, notification_channel, storage_integration, endpoint, owner_role_type,
         directory_enabled)
@@ -94,13 +106,11 @@ def create_stage(
             '{now}', '{stage_name}', '{catalog}', '{schema}', '{url}', 'N', 'N', 'SYSADMIN',
             '', NULL, '{stage_type}', {f"'{cloud}'" if cloud else "NULL"}, NULL, NULL, NULL, 'ROLE',
             'N'
-        WHERE NOT EXISTS (
-            SELECT 1 FROM _fs_global._fs_information_schema._fs_stages
-            WHERE name = '{stage_name}' AND database_name = '{catalog}' AND schema_name = '{schema}'
-        )
+        {guard}
         """
     transformed = sqlglot.parse_one(insert_sql, read="duckdb")
     transformed.args["create_stage_name"] = stage_name
+    transformed.args["create_stage_if_not_exists"] = if_not_exists
     return transformed
 
 

--- a/tests/test_copy_into.py
+++ b/tests/test_copy_into.py
@@ -252,6 +252,43 @@ def test_copy_internal_stage_format_name_and_path(dcur: snowflake.connector.curs
         assert dcur.fetchall() == [{"A": 1, "B": 2}, {"A": None, "B": 4}]
 
 
+def test_copy_internal_table_stage(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    create_table(dcur)
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as temp_file:
+        data = "1,2\n"
+        temp_file.write(data)
+        temp_file.flush()
+        temp_file_path = temp_file.name
+        temp_file_basename = os.path.basename(temp_file_path)
+
+        # a table stage exists implicitly for every table
+        dcur.execute(f"PUT 'file://{temp_file_path}' @db1.schema1.%table1")
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["target"] == f"{temp_file_basename}.gz"
+
+        dcur.execute(f"COPY INTO table1 FROM @db1.schema1.%table1/{temp_file_basename}.gz")
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["status"] == "LOADED"
+
+        dcur.execute("SELECT * FROM table1")
+        assert dcur.fetchall() == [{"A": 1, "B": 2}]
+
+
+def test_put_table_stage_non_existent_table(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as temp_file:
+        temp_file_path = temp_file.name
+
+        with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+            dcur.execute(f"PUT 'file://{temp_file_path}' @%foobar")
+
+        assert (
+            str(excinfo.value)
+            == "002003 (02000): SQL compilation error:\nStage 'DB1.SCHEMA1.%FOOBAR' does not exist or not authorized."
+        )
+
+
 def test_copy_format_name_does_not_exist(dcur: snowflake.connector.cursor.DictCursor) -> None:
     create_table(dcur)
     dcur.execute("CREATE STAGE stage3")

--- a/tests/test_copy_into.py
+++ b/tests/test_copy_into.py
@@ -18,7 +18,7 @@ from mypy_boto3_s3 import S3Client
 from sqlglot import exp
 
 from fakesnow import logger
-from fakesnow.copy_into import CopyParams, _from_source, _params, _source_urls, _strip_json_extract
+from fakesnow.copy_into import CopyParams, ReadCSV, _from_source, _params, _source_urls, _strip_json_extract
 from tests.utils import dindent
 
 
@@ -217,6 +217,51 @@ def test_copy_internal_stage_server(sdcur: snowflake.connector.cursor.DictCursor
         dcur.execute("LIST @stage3")
         results = dcur.fetchall()
         assert len(results) == 0
+
+
+def test_copy_internal_stage_format_name_and_path(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    create_table(dcur)
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as temp_file:
+        data = 'A,B\n"1",2\n,4\n'
+        temp_file.write(data)
+        temp_file.flush()
+        temp_file_path = temp_file.name
+        temp_file_basename = os.path.basename(temp_file_path)
+
+        dcur.execute("CREATE STAGE stage3")
+        dcur.execute(f"PUT 'file://{temp_file_path}' @stage3")
+        dcur.execute("""
+            CREATE FILE FORMAT my_csv_format TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1
+            FIELD_OPTIONALLY_ENCLOSED_BY='"' EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE'
+        """)
+
+        # reference a single file within the stage and a named file format
+        dcur.execute(f"""
+            COPY INTO table1
+            FROM @stage3/{temp_file_basename}.gz
+            FILE_FORMAT = (FORMAT_NAME = 'my_csv_format')
+            ON_ERROR = 'ABORT_STATEMENT'
+        """)
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["file"] == f"stage3/{temp_file_basename}.gz"
+        assert results[0]["status"] == "LOADED"
+        assert results[0]["rows_loaded"] == 2
+
+        dcur.execute("SELECT * FROM table1")
+        assert dcur.fetchall() == [{"A": 1, "B": 2}, {"A": None, "B": 4}]
+
+
+def test_copy_format_name_does_not_exist(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    create_table(dcur)
+    dcur.execute("CREATE STAGE stage3")
+
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+        dcur.execute("COPY INTO table1 FROM @stage3 FILE_FORMAT = (FORMAT_NAME = 'unknown_format')")
+
+    assert str(excinfo.value) == (
+        "002003 (02000): SQL compilation error:\nFile format 'UNKNOWN_FORMAT' does not exist or not authorized."
+    )
 
 
 @patch("fakesnow.copy_into.logger.log_sql", side_effect=logger.log_sql)
@@ -793,6 +838,45 @@ def test_load_history_is_per_table(dcur: snowflake.connector.cursor.DictCursor, 
     dcur.execute("CREATE OR REPLACE TABLE schema1.table1 (a INT, b INT)")
     dcur.execute(sql.format(table="table1", bucket=bucket))
     assert dcur.fetchall()[0]["status"] == "LOADED"
+
+
+def test_params_csv_options():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1 FIELD_OPTIONALLY_ENCLOSED_BY='"'
+        EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE' COMPRESSION='GZIP')
+    ON_ERROR = 'ABORT_STATEMENT'
+    """)
+
+    assert params.file_format == ReadCSV(skip_header=1, quote='"', delimiter=",", null_if=[""], compression="gzip")
+    assert params.on_error == "ABORT_STATEMENT"
+
+    assert (
+        params.file_format.read_expression("s3://mybucket/data/file1.csv").sql(dialect="duckdb")
+        == "READ_CSV('s3://mybucket/data/file1.csv', header = FALSE, skip = 1, quote = '\"', nullstr = [''], compression = 'gzip')"
+    )
+
+
+def test_params_csv_null_if_multiple():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' NULL_IF=('NULL', 'null'))
+    """)
+
+    # EMPTY_FIELD_AS_NULL defaults to TRUE, so '' is included
+    assert params.file_format == ReadCSV(null_if=["", "NULL", "null"])
+
+
+def test_params_csv_empty_field_as_null_false():
+    _, params = parse("""
+    COPY INTO table1
+    FROM 's3://mybucket/data/'
+    FILE_FORMAT = (TYPE='CSV' EMPTY_FIELD_AS_NULL=FALSE)
+    """)
+
+    assert params.file_format == ReadCSV(null_if=[])
 
 
 def test__strip_json_extract():

--- a/tests/test_file_format.py
+++ b/tests/test_file_format.py
@@ -1,0 +1,35 @@
+import pytest
+import snowflake.connector.cursor
+
+
+def test_create_file_format(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+    with pytest.raises(snowflake.connector.errors.ProgrammingError) as excinfo:
+        dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV'")
+
+    assert str(excinfo.value) == "002002 (42710): SQL compilation error:\nObject 'MY_FMT' already exists."
+
+
+def test_create_file_format_or_replace(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT my_fmt TYPE='CSV'")
+
+    dcur.execute("CREATE OR REPLACE FILE FORMAT my_fmt TYPE='CSV' SKIP_HEADER=1")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+
+def test_create_file_format_if_not_exists(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE FILE FORMAT IF NOT EXISTS my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]
+
+    dcur.execute("CREATE FILE FORMAT IF NOT EXISTS my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "MY_FMT already exists, statement succeeded."}]
+
+
+def test_create_file_format_fully_qualified(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE DATABASE db2")
+    dcur.execute("CREATE SCHEMA db2.schema2")
+
+    dcur.execute("CREATE FILE FORMAT db2.schema2.my_fmt TYPE='CSV'")
+    assert dcur.fetchall() == [{"status": "File format MY_FMT successfully created."}]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,7 +19,7 @@ from dirty_equals import IsDatetime, IsUUID
 from pandas.testing import assert_frame_equal
 from snowflake.connector.cursor import ResultMetadata
 
-from tests.utils import indent
+from tests.utils import dindent, indent
 
 
 def test_server_abort_request(server: dict) -> None:
@@ -722,3 +722,47 @@ def test_server_bulk_load_pipeline(sdcur: snowflake.connector.cursor.DictCursor)
 
             dcur.execute("SELECT * FROM target ORDER BY id")
             assert dcur.fetchall() == [{"ID": 1, "NAME": "foo"}, {"ID": 2, "NAME": None}]
+
+
+def test_server_table_stage_bulk_load(sdcur: snowflake.connector.cursor.DictCursor) -> None:
+    # PUT a gzipped csv with a header row to a fully-qualified table stage, then COPY it,
+    # including VARIANT columns fed from csv strings
+    dcur = sdcur
+    dcur.execute("""
+        CREATE OR REPLACE TABLE db1.schema1.snap_t (
+            release_tag VARCHAR(100) NOT NULL, permissions VARIANT NOT NULL,
+            provider_details VARIANT, created_at TIMESTAMP NOT NULL)
+    """)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        path = f"{tmp_dir}/snap_t.csv.gz"
+        with gzip.open(path, "wt") as f:
+            f.write("RELEASE_TAG,PERMISSIONS,PROVIDER_DETAILS,CREATED_AT\n")
+            f.write('v1,"{""a"": 1}",,2024-01-01 00:00:00\n')
+
+        dcur.execute(f"PUT file://{path} @db1.schema1.%snap_t AUTO_COMPRESS=FALSE")
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["target"] == "snap_t.csv.gz"
+        assert results[0]["status"] == "UPLOADED"
+
+        dcur.execute("""
+            COPY INTO db1.schema1.snap_t FROM @db1.schema1.%snap_t/snap_t.csv.gz
+            FILE_FORMAT = (TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1 FIELD_OPTIONALLY_ENCLOSED_BY='"'
+            EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE')
+            ON_ERROR='ABORT_STATEMENT'
+        """)
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["status"] == "LOADED"
+        assert results[0]["rows_loaded"] == 1
+
+        dcur.execute("SELECT * FROM db1.schema1.snap_t")
+        assert dindent(dcur.fetchall()) == [
+            {
+                "RELEASE_TAG": "v1",
+                "PERMISSIONS": '{\n  "a": 1\n}',
+                "PROVIDER_DETAILS": None,
+                "CREATED_AT": datetime.datetime(2024, 1, 1, 0, 0),
+            }
+        ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,7 @@
 # ruff: noqa: E501
 
 import datetime
+import gzip
 import os
 import tempfile
 import uuid
@@ -678,3 +679,46 @@ def test_server_describe_only(server: dict) -> None:
         # nothing ran: the original table is untouched
         cur.execute("select * from example")
         assert cur.fetchall() == [(1, "old")]
+
+
+def test_server_bulk_load_pipeline(sdcur: snowflake.connector.cursor.DictCursor) -> None:
+    # stage/PUT/COPY/MERGE bulk-load pipeline as used by eg: a data-sync job.
+    # run twice to prove CREATE OR REPLACE STAGE/FILE FORMAT/TABLE work on rerun.
+    dcur = sdcur
+    dcur.execute("CREATE OR REPLACE TABLE target (id INT, name VARCHAR)")
+
+    for run in (1, 2):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = f"{tmp_dir}/data.csv.gz"
+            with gzip.open(path, "wt") as f:
+                f.write('ID,NAME\n1,"foo"\n2,\n')
+
+            dcur.execute("CREATE OR REPLACE STAGE bulk_stage FILE_FORMAT = (TYPE = 'CSV')")
+            dcur.execute("""
+                CREATE OR REPLACE FILE FORMAT bulk_csv_format TYPE='CSV' FIELD_DELIMITER=',' SKIP_HEADER=1
+                FIELD_OPTIONALLY_ENCLOSED_BY='"' EMPTY_FIELD_AS_NULL=TRUE NULL_IF=('') ESCAPE_UNENCLOSED_FIELD='NONE'
+            """)
+            dcur.execute("CREATE OR REPLACE TEMPORARY TABLE staging (id INT, name VARCHAR)")
+
+            dcur.execute(f"PUT file://{path} @bulk_stage AUTO_COMPRESS=FALSE")
+            results = dcur.fetchall()
+            assert results[0]["target"] == "data.csv.gz", f"run {run}: {results}"
+
+            dcur.execute("""
+                COPY INTO staging
+                FROM @bulk_stage/data.csv.gz
+                FILE_FORMAT = (FORMAT_NAME = 'bulk_csv_format')
+                ON_ERROR = 'ABORT_STATEMENT'
+            """)
+            results = dcur.fetchall()
+            assert results[0]["status"] == "LOADED", f"run {run}: {results}"
+            assert results[0]["rows_loaded"] == 2
+
+            dcur.execute("""
+                MERGE INTO target t USING staging s ON t.id = s.id
+                WHEN MATCHED THEN UPDATE SET t.name = s.name
+                WHEN NOT MATCHED THEN INSERT (id, name) VALUES (s.id, s.name)
+            """)
+
+            dcur.execute("SELECT * FROM target ORDER BY id")
+            assert dcur.fetchall() == [{"ID": 1, "NAME": "foo"}, {"ID": 2, "NAME": None}]

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -1,3 +1,4 @@
+import gzip
 import os
 import tempfile
 from datetime import timezone
@@ -177,3 +178,57 @@ def test_put_list(dcur: snowflake.connector.cursor.DictCursor) -> None:
         # fully qualified stage name quoted
         dcur.execute('CREATE STAGE db1.schema1."stage5"')
         dcur.execute(f"PUT 'file://{temp_file_path}' @db1.schema1.\"stage5\"")
+
+
+def test_put_unquoted_src_auto_compress_false(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as temp_file:
+        data = "1,2\n"
+        temp_file.write(data)
+        temp_file.flush()
+        temp_file_path = temp_file.name
+        temp_file_basename = os.path.basename(temp_file_path)
+
+        dcur.execute("CREATE STAGE stage6")
+        dcur.execute(f"PUT file://{temp_file_path} @stage6 AUTO_COMPRESS=FALSE")
+        assert dcur.fetchall() == [
+            {
+                "source": temp_file_basename,
+                "target": temp_file_basename,
+                "source_size": len(data),
+                "target_size": len(data),
+                "source_compression": "NONE",
+                "target_compression": "NONE",
+                "status": "UPLOADED",
+                "message": "",
+            }
+        ]
+
+        dcur.execute("LIST @stage6")
+        results = dcur.fetchall()
+        assert len(results) == 1
+        assert results[0]["name"] == f"stage6/{temp_file_basename}"
+        assert results[0]["size"] == len(data)
+
+
+def test_put_gzipped_src_not_recompressed(dcur: snowflake.connector.cursor.DictCursor) -> None:
+    with tempfile.NamedTemporaryFile(suffix=".csv.gz") as temp_file:
+        data = gzip.compress(b"1,2\n")
+        temp_file.write(data)
+        temp_file.flush()
+        temp_file_path = temp_file.name
+        temp_file_basename = os.path.basename(temp_file_path)
+
+        dcur.execute("CREATE STAGE stage7")
+        dcur.execute(f"PUT 'file://{temp_file_path}' @stage7")
+        assert dcur.fetchall() == [
+            {
+                "source": temp_file_basename,
+                "target": temp_file_basename,
+                "source_size": len(data),
+                "target_size": len(data),
+                "source_compression": "GZIP",
+                "target_compression": "GZIP",
+                "status": "UPLOADED",
+                "message": "",
+            }
+        ]

--- a/tests/test_stage.py
+++ b/tests/test_stage.py
@@ -106,6 +106,29 @@ def test_create_stage(dcur: snowflake.connector.cursor.SnowflakeCursor):
     ]
 
 
+def test_create_stage_or_replace(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE STAGE stage1")
+
+    dcur.execute("CREATE OR REPLACE STAGE stage1 URL='s3://bucket/path/'")
+    assert dcur.fetchall() == [{"status": "Stage area STAGE1 successfully created."}]
+
+    dcur.execute("SHOW STAGES")
+    rows = dcur.fetchall()
+    assert len(rows) == 1
+    assert rows[0]["url"] == "s3://bucket/path/"
+
+
+def test_create_stage_if_not_exists(dcur: snowflake.connector.cursor.DictCursor):
+    dcur.execute("CREATE STAGE IF NOT EXISTS stage1")
+    assert dcur.fetchall() == [{"status": "Stage area STAGE1 successfully created."}]
+
+    dcur.execute("CREATE STAGE IF NOT EXISTS stage1")
+    assert dcur.fetchall() == [{"status": "STAGE1 already exists, statement succeeded."}]
+
+    dcur.execute("SHOW STAGES")
+    assert len(dcur.fetchall()) == 1
+
+
 def test_create_stage_qmark_quoted(_fakesnow: None):
     with (
         snowflake.connector.connect(database="db1", schema="schema1", paramstyle="qmark") as conn,


### PR DESCRIPTION
Depends on #412 (based on its branch) — contains its commits until it merges. Please merge #412 first; I'll rebase this PR right after so only its own 4 commits remain. (If this one is merged first instead, #412 can simply be closed as already included.)

- **Unquoted PUT urls**: sqlglot only parses PUT as `exp.Put` when the source is a quoted literal, so an unquoted url (as sent by eg: snowflake-sqlalchemy) fell through to duckdb as a raw command; the source is quoted before parsing. `AUTO_COMPRESS`, `OVERWRITE`, `PARALLEL` and `SOURCE_COMPRESSION` are honoured, and an already gzipped source is no longer recompressed.
- **PUT over http in server mode**: the server returned a LOCAL_FS stage location, so the connector wrote the file to the client's own filesystem; when the client doesn't share the server's filesystem (eg: the server runs in a container) a subsequent COPY INTO silently found no files. The server now returns a GCS-style stage info with a presigned url pointing back at the fakesnow server, so the connector uploads the file over http into the stage's backing storage (GCS is the only location type the connector uploads to via a plain http presigned url). A PUT with a `?` placeholder target keeps LOCAL_FS because the connector re-requests the presigned url by executing the command without bindings.
- **Table stages**: a stage name starting with `%` is a table stage, which exists implicitly for every table: existence is checked against the table catalog rather than the stage registry, and its files live in the internal-stage backing storage. Out of scope: `LIST @%table`, which sqlglot cannot parse.
- Includes an end-to-end server-mode test running the full stage/PUT/COPY/MERGE pipeline twice on one server (the rerun needs #411's per-table load history, hence the carried commit).

Fixes #409. Split out of #400 per maintainer request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


