### PR TITLE
feat: support USE ROLE/WAREHOUSE as NOP instead of raising

### DIFF
--- a/fakesnow/checks.py
+++ b/fakesnow/checks.py
@@ -106,7 +106,10 @@ def _missing_qualifiers(node: exp.Table) -> tuple[bool, bool]:
             no_database = not node.args.get("db")
             no_schema = False
         else:
-            raise AssertionError(f"Unexpected parent kind: {parent_kind.name}")
+            # "USE ROLE/WAREHOUSE" and friends name a role or warehouse rather than a table,
+            # so there's nothing to qualify
+            no_database = False
+            no_schema = False
 
     elif node.parent.key == "show":
         # don't require a database or schema for SHOW

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1039,6 +1039,8 @@ def set_schema(expression: Expr, current_database: str | None) -> Expr:
         "SET schema = 'foo.bar'"
         >>> sqlglot.parse_one("USE DATABASE marts").transform(set_schema).sql()
         "SET schema = 'marts.main'"
+        >>> sqlglot.parse_one("USE ROLE analyst").transform(set_schema).sql()
+        "SELECT 'Statement executed successfully.' AS status"
 
         See tests for more examples.
     Args:
@@ -1054,8 +1056,11 @@ def set_schema(expression: Expr, current_database: str | None) -> Expr:
         and (kind := expression.args.get("kind"))
         and isinstance(kind, exp.Var)
         and kind.name
-        and kind.name.upper() in ["SCHEMA", "DATABASE"]
     ):
+        if kind.name.upper() not in ["SCHEMA", "DATABASE"]:
+            # duckdb has no roles or warehouses, so USE ROLE/WAREHOUSE is a NOP
+            return SUCCESS_NOP
+
         assert expression.this, f"No identifier for USE expression {expression}"
 
         if kind.name.upper() == "DATABASE":

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -628,6 +628,17 @@ def test_unquoted_identifiers_are_upper_cased(dcur: snowflake.connector.cursor.S
     ]
 
 
+def test_use_role_and_warehouse(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # duckdb has no roles or warehouses, but clients still issue these on connect, so
+    # they succeed without changing the current database or schema
+    for sql in ['use role "duckdb"', "use role analyst", "use warehouse compute_wh"]:
+        cur.execute(sql)
+        assert cur.fetchall() == [("Statement executed successfully.",)]
+
+    cur.execute("select current_database(), current_schema()")
+    assert cur.fetchall() == [("DB1", "SCHEMA1")]
+
+
 def test_use_invalid_schema(_fakesnow: None):
     # database will be created but not schema
     with snowflake.connector.connect(database="marts") as conn, conn.cursor() as cur:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -505,9 +505,8 @@ def test_server_rowcount(scur: snowflake.connector.cursor.SnowflakeCursor):
     ],
 )
 def test_server_query_response_has_use_statement_type_id(server: dict, sql: str) -> None:
-    session_parameters = server.get("session_parameters", {}) | {"nop_regexes": [r"use (role|warehouse)"]}
     with snowflake.connector.connect(
-        **(server | {"session_parameters": session_parameters}),
+        **server,
         database="db1",
         schema="schema1",
     ) as conn:

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -895,6 +895,17 @@ def test_use() -> None:
         == "SET schema = 'foo.bar'"
     )
 
+    # roles and warehouses have no duckdb equivalent, so they're a NOP rather than an error
+    assert (
+        sqlglot.parse_one("use role analyst").transform(set_schema, current_database="marts").sql()
+        == "SELECT 'Statement executed successfully.' AS status"
+    )
+
+    assert (
+        sqlglot.parse_one("use warehouse compute_wh").transform(set_schema, current_database="marts").sql()
+        == "SELECT 'Statement executed successfully.' AS status"
+    )
+
 
 def test__get_to_number_args() -> None:
     default_precision = exp.Literal(this="38", is_string=False)


### PR DESCRIPTION
`USE ROLE` and `USE WAREHOUSE` raise an `AssertionError` rather than succeeding:

```python
with fakesnow.patch():
    conn = snowflake.connector.connect(database="db1", schema="schema1")
    conn.cursor().execute('USE ROLE "duckdb"')
    # AssertionError: Unexpected parent kind: ROLE
```

In server mode the same statement comes back as a 500, because the assertion isn't a `ProgrammingError`:

```
ERROR: sql_text='USE ROLE "duckdb"' params=None Unhandled exception
  File "fakesnow/checks.py", line 109, in _missing_qualifiers
    raise AssertionError(f"Unexpected parent kind: {parent_kind.name}")
"POST /queries/v1/query-request" 500 Internal Server Error
```

`_missing_qualifiers` only knows the `USE DATABASE` and `USE SCHEMA` kinds, and asserts on the rest. But a role or warehouse isn't a table, so there's no qualifier to check — those kinds can just report nothing missing. `set_schema` already owns `exp.Use`, so the NOP goes there next to the existing kinds rather than in a new transform.

duckdb has no roles or warehouses, so a NOP seemed closer to snowflake than an error — snowflake returns `Statement executed successfully.` for these, which is what `SUCCESS_NOP` gives.

I hit this running Flyway against fakesnow over JDBC: it issues `USE ROLE` while setting up the connection and dies on the 500. There are a couple of other things in its way that I'll write up separately, this one just looked like a plain bug.

Verified `USE ROLE`/`USE WAREHOUSE` succeed and leave the current database and schema alone, and that `USE DATABASE`/`USE SCHEMA` still work. Full suite passes (`test_cli.py::test_run_server` fails on main here too, unrelated).
