### PR TITLE
feat: report a server version from CURRENT_VERSION() and the login response

### DIFF
--- a/fakesnow/server.py
+++ b/fakesnow/server.py
@@ -25,6 +25,7 @@ from fakesnow.fakes import FakeSnowflakeConnection
 from fakesnow.instance import FakeSnow
 from fakesnow.rowtype import ColumnInfo, describe_as_rowtype
 from fakesnow.statement_type import DML_TYPE_IDS, statement_type_id
+from fakesnow.transforms import SERVER_VERSION
 
 logger = logging.getLogger("fakesnow.server")
 # use same format as uvicorn
@@ -67,6 +68,9 @@ async def login_request(request: Request) -> JSONResponse:
         {
             "data": {
                 "token": token,
+                # clients serve this as the jdbc database product version, and some refuse to run
+                # against a version they consider too old
+                "serverVersion": SERVER_VERSION,
                 "parameters": [
                     {"name": "AUTOCOMMIT", "value": autocommit},
                     {"name": "CLIENT_SESSION_KEEP_ALIVE_HEARTBEAT_FREQUENCY", "value": 3600},

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -24,6 +24,7 @@ from fakesnow.transforms.stage import (
     put_stage as put_stage,
 )
 from fakesnow.transforms.transforms import (
+    SERVER_VERSION as SERVER_VERSION,
     SUCCESS_NOP as SUCCESS_NOP,
     alias_in_join as alias_in_join,
     alter_session as alter_session,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -15,6 +15,10 @@ from fakesnow.variables import Variables
 
 SUCCESS_NOP = sqlglot.parse_one("SELECT 'Statement executed successfully.' as status")
 
+# the version fakesnow reports as the snowflake server version, both from CURRENT_VERSION() and in
+# the login response. clients gate on the major version, eg: flyway won't run below snowflake 3.
+SERVER_VERSION = "10.0.0"
+
 
 def alias_in_join(expression: Expr) -> Expr:
     if (
@@ -163,7 +167,7 @@ def current_version(expression: Expr) -> Expr:
     """
 
     if isinstance(expression, exp.CurrentVersion):
-        return exp.Literal(this="0.0.0", is_string=True)
+        return exp.Literal(this=SERVER_VERSION, is_string=True)
 
     return expression
 

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -147,8 +147,6 @@ def test_connect_current_version(cur: snowflake.connector.cursor.SnowflakeCursor
     version = cur.execute("SELECT CURRENT_VERSION()").fetchone()
 
     assert version == ("10.0.0",)
-    # clients gate on the major version, so it needs to look like a current snowflake
-    assert int(version[0].split(".")[0]) >= 10
 
 
 def test_connect_then_unset_schema(_fakesnow: None):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -12,6 +12,7 @@ import snowflake.connector.cursor
 import snowflake.connector.pandas_tools
 
 import fakesnow
+from fakesnow.transforms import SERVER_VERSION
 
 
 def test_close_conn(conn: snowflake.connector.SnowflakeConnection):
@@ -147,7 +148,9 @@ def test_connect_current_version(cur: snowflake.connector.cursor.SnowflakeCursor
     version = cur.execute("SELECT CURRENT_VERSION()").fetchone()
 
     assert version
-    assert tuple(int(part) for part in version[0].split(".")) == (0, 0, 0)
+    assert tuple(int(part) for part in version[0].split(".")) == tuple(int(part) for part in SERVER_VERSION.split("."))
+    # clients gate on the major version, so it needs to look like a current snowflake
+    assert int(SERVER_VERSION.split(".")[0]) >= 10
 
 
 def test_connect_then_unset_schema(_fakesnow: None):

--- a/tests/test_connect.py
+++ b/tests/test_connect.py
@@ -12,7 +12,6 @@ import snowflake.connector.cursor
 import snowflake.connector.pandas_tools
 
 import fakesnow
-from fakesnow.transforms import SERVER_VERSION
 
 
 def test_close_conn(conn: snowflake.connector.SnowflakeConnection):
@@ -147,10 +146,9 @@ def test_connect_information_schema():
 def test_connect_current_version(cur: snowflake.connector.cursor.SnowflakeCursor):
     version = cur.execute("SELECT CURRENT_VERSION()").fetchone()
 
-    assert version
-    assert tuple(int(part) for part in version[0].split(".")) == tuple(int(part) for part in SERVER_VERSION.split("."))
+    assert version == ("10.0.0",)
     # clients gate on the major version, so it needs to look like a current snowflake
-    assert int(SERVER_VERSION.split(".")[0]) >= 10
+    assert int(version[0].split(".")[0]) >= 10
 
 
 def test_connect_then_unset_schema(_fakesnow: None):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,6 +18,7 @@ from dirty_equals import IsDatetime, IsUUID
 from pandas.testing import assert_frame_equal
 from snowflake.connector.cursor import ResultMetadata
 
+from fakesnow.transforms import SERVER_VERSION
 from tests.utils import indent
 
 
@@ -160,6 +161,20 @@ def test_server_client_session_keep_alive(server: dict) -> None:
     with snowflake.connector.connect(**server | {"client_session_keep_alive": True}):
         # shouldn't error
         pass
+
+
+def test_server_login_reports_server_version(server: dict) -> None:
+    # the jdbc driver reads data.serverVersion from the login response and serves it as
+    # DatabaseMetaData.getDatabaseProductVersion(). the python connector ignores it, so assert
+    # on the response itself.
+    response = requests.post(
+        f"http://{server['host']}:{server['port']}/session/v1/login-request",
+        json={"data": {"ACCOUNT_NAME": "fakesnow", "LOGIN_NAME": "fake", "SESSION_PARAMETERS": {}}},
+        timeout=5,
+    )
+
+    assert response.status_code == 200
+    assert response.json()["data"]["serverVersion"] == SERVER_VERSION
 
 
 def test_server_executemany_qmark(server: dict) -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -18,7 +18,6 @@ from dirty_equals import IsDatetime, IsUUID
 from pandas.testing import assert_frame_equal
 from snowflake.connector.cursor import ResultMetadata
 
-from fakesnow.transforms import SERVER_VERSION
 from tests.utils import indent
 
 
@@ -174,7 +173,7 @@ def test_server_login_reports_server_version(server: dict) -> None:
     )
 
     assert response.status_code == 200
-    assert response.json()["data"]["serverVersion"] == SERVER_VERSION
+    assert response.json()["data"]["serverVersion"] == "10.0.0"
 
 
 def test_server_executemany_qmark(server: dict) -> None:


### PR DESCRIPTION
First of the #416 items.

The login response didn't carry `serverVersion`, so the jdbc driver had nothing to serve from `DatabaseMetaData.getDatabaseProductVersion()`:

```
productVersion    = ''
CURRENT_VERSION() = '0.0.0'
```

which is what Flyway rejects:

```
Snowflake upgrade required: Snowflake 0.0 is outdated and no longer supported by Flyway.
Flyway currently supports Snowflake 3.0 and newer.
```

Going with a 10 major as you said, and putting it in one constant used by both `current_version` and the login response, rather than letting them drift. Real Snowflake reports `10.31.103` today, so `10.0.0` matches the major without pretending to track a patch level that'll go stale.

After this, against the same server:

```
productVersion = '10.0.0'
productName    = 'Snowflake'
```

The existing `test_connect_current_version` now compares against the constant instead of a literal, plus an assertion on the major so it doesn't get dropped back below what clients accept. The new server test asserts the login response directly — the python connector never reads `serverVersion`, only the jdbc driver does, so there's nothing to check through the connector API.

`productVersion` above is from the real 3.19.0 driver against `fakesnow -s`, not a test double. Full suite passes (`test_cli.py::test_run_server` fails on main here too, unrelated).

`SHOW SEQUENCES` next.
