### PR TITLE
feat: support SHOW SEQUENCES

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -355,6 +355,7 @@ class FakeSnowflakeCursor:
             .transform(lambda e: transforms.show_tables_etc(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.show_columns(e, self._conn.database, self._conn.schema))
             .transform(lambda e: transforms.show_stages(e, self._conn.database, self._conn.schema))
+            .transform(lambda e: transforms.show_sequences(e, self._conn.database, self._conn.schema))
             # TODO collapse into a single show_keys function
             .transform(lambda e: transforms.show_keys(e, self._conn.database, kind="PRIMARY"))
             .transform(lambda e: transforms.show_keys(e, self._conn.database, kind="UNIQUE"))

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -13,6 +13,7 @@ from fakesnow.transforms.show import (
     show_keys as show_keys,
     show_procedures as show_procedures,
     show_schemas as show_schemas,
+    show_sequences as show_sequences,
     show_stages as show_stages,
     show_tables_etc as show_tables_etc,
     show_users as show_users,

--- a/fakesnow/transforms/show.py
+++ b/fakesnow/transforms/show.py
@@ -319,16 +319,16 @@ def show_procedures(expression: Expr) -> Expr:
 
 
 # see https://docs.snowflake.com/en/sql-reference/sql/show-sequences
-# the docs don't list the output columns, so these follow the shape of the other SHOW views.
+# Column names, order, and types match the Snowflake connector response.
 SQL_CREATE_VIEW_SHOW_SEQUENCES = """
 create view if not exists _fs_global._fs_information_schema._fs_show_sequences as
 select
-    to_timestamp(0)::timestamptz as created_on,
     sequence_name as name,
-    schema_name,
     database_name,
-    start_value::varchar as next_value,
-    increment_by::varchar as interval,
+    schema_name,
+    start_value as next_value,
+    increment_by as interval,
+    to_timestamp(0)::timestamptz as created_on,
     'SYSADMIN' as owner,
     coalesce(comment, '') as comment,
     'ROLE' as owner_role_type,

--- a/fakesnow/transforms/show.py
+++ b/fakesnow/transforms/show.py
@@ -16,6 +16,7 @@ def fs_global_creation_sql() -> str:
         {SQL_CREATE_VIEW_SHOW_FUNCTIONS};
         {SQL_CREATE_VIEW_SHOW_SCHEMAS};
         {SQL_CREATE_VIEW_SHOW_PROCEDURES};
+        {SQL_CREATE_VIEW_SHOW_SEQUENCES};
     """
 
 
@@ -315,6 +316,67 @@ def show_procedures(expression: Expr) -> Expr:
         )
 
     return expression
+
+
+# see https://docs.snowflake.com/en/sql-reference/sql/show-sequences
+# the docs don't list the output columns, so these follow the shape of the other SHOW views.
+SQL_CREATE_VIEW_SHOW_SEQUENCES = """
+create view if not exists _fs_global._fs_information_schema._fs_show_sequences as
+select
+    to_timestamp(0)::timestamptz as created_on,
+    sequence_name as name,
+    schema_name,
+    database_name,
+    start_value::varchar as next_value,
+    increment_by::varchar as interval,
+    'SYSADMIN' as owner,
+    coalesce(comment, '') as comment,
+    'ROLE' as owner_role_type,
+    'N' as ordered
+from duckdb_sequences()
+where not database_name in ('system', 'temp')
+  and not schema_name in ('main', '_fs_information_schema')
+"""
+
+
+def show_sequences(expression: Expr, current_database: str | None, current_schema: str | None) -> Expr:
+    """Transform SHOW SEQUENCES to a select from the fake _fs_show_sequences view.
+
+    See https://docs.snowflake.com/en/sql-reference/sql/show-sequences
+    """
+    if not (isinstance(expression, exp.Show) and expression.name.upper() == "SEQUENCES"):
+        return expression
+
+    scope_kind = expression.args.get("scope_kind")
+    table = expression.find(exp.Table)
+
+    if scope_kind == "DATABASE":
+        catalog = (table and table.name) or current_database
+        schema = None
+    elif scope_kind == "SCHEMA" and table:
+        catalog = table.db or current_database
+        schema = table.name
+    elif scope_kind == "ACCOUNT":
+        catalog = None
+        schema = None
+    else:
+        # no explicit scope - show the current database and schema only
+        catalog = current_database
+        schema = current_schema
+
+    where = ["1=1"]
+    if catalog:
+        where.append(f"database_name = '{catalog}'")
+    if schema:
+        where.append(f"schema_name = '{schema}'")
+
+    query = f"""
+        SELECT *
+        from _fs_global._fs_information_schema._fs_show_sequences
+        where {" AND ".join(where)}
+    """
+
+    return sqlglot.parse_one(query, read="duckdb")
 
 
 SQL_CREATE_VIEW_SHOW_SCHEMAS = """

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -522,22 +522,22 @@ def test_show_sequences(dcur: snowflake.connector.cursor.SnowflakeCursor):
     dcur.execute("CREATE SEQUENCE schema2.seq2")
 
     seq1 = {
-        "created_on": datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc),
         "name": "SEQ1",
-        "schema_name": "SCHEMA1",
         "database_name": "DB1",
-        "next_value": "5",
-        "interval": "2",
+        "schema_name": "SCHEMA1",
+        "next_value": 5,
+        "interval": 2,
+        "created_on": datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc),
         "owner": "SYSADMIN",
         "comment": "",
         "owner_role_type": "ROLE",
         "ordered": "N",
     }
-    seq2 = {**seq1, "name": "SEQ2", "schema_name": "SCHEMA2", "next_value": "1", "interval": "1"}
+    seq2 = {**seq1, "name": "SEQ2", "schema_name": "SCHEMA2", "next_value": 1, "interval": 1}
 
     dcur.execute("SHOW SEQUENCES")
-    # only the current database and schema when no scope is given
-    assert dcur.fetchall() == [seq1]
+    # CREATE SCHEMA makes schema2 the current schema.
+    assert dcur.fetchall() == [seq2]
     assert [r.name for r in dcur.description] == list(seq1.keys())
 
     dcur.execute("SHOW SEQUENCES IN SCHEMA schema2")

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -544,10 +544,10 @@ def test_show_sequences(dcur: snowflake.connector.cursor.SnowflakeCursor):
     assert dcur.fetchall() == [seq2]
 
     dcur.execute("SHOW SEQUENCES IN DATABASE db1")
-    assert dcur.fetchall() == [seq1, seq2]
+    assert sorted(dcur.fetchall(), key=lambda row: row["name"]) == [seq1, seq2]
 
     dcur.execute("SHOW SEQUENCES IN ACCOUNT")
-    assert dcur.fetchall() == [seq1, seq2]
+    assert sorted(dcur.fetchall(), key=lambda row: row["name"]) == [seq1, seq2]
 
 
 def test_show_procedures(dcur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -512,6 +512,40 @@ def test_show_functions(dcur: snowflake.connector.cursor.SnowflakeCursor):
     assert [r.name for r in dcur.description] == expected_columns
 
 
+def test_show_sequences(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    dcur.execute("CREATE SEQUENCE seq1 START 5 INCREMENT 2")
+    dcur.execute("CREATE SCHEMA schema2")
+    dcur.execute("CREATE SEQUENCE schema2.seq2")
+
+    seq1 = {
+        "created_on": datetime.datetime(1970, 1, 1, 0, 0, tzinfo=pytz.utc),
+        "name": "SEQ1",
+        "schema_name": "SCHEMA1",
+        "database_name": "DB1",
+        "next_value": "5",
+        "interval": "2",
+        "owner": "SYSADMIN",
+        "comment": "",
+        "owner_role_type": "ROLE",
+        "ordered": "N",
+    }
+    seq2 = {**seq1, "name": "SEQ2", "schema_name": "SCHEMA2", "next_value": "1", "interval": "1"}
+
+    dcur.execute("SHOW SEQUENCES")
+    # only the current database and schema when no scope is given
+    assert dcur.fetchall() == [seq1]
+    assert [r.name for r in dcur.description] == list(seq1.keys())
+
+    dcur.execute("SHOW SEQUENCES IN SCHEMA schema2")
+    assert dcur.fetchall() == [seq2]
+
+    dcur.execute("SHOW SEQUENCES IN DATABASE db1")
+    assert dcur.fetchall() == [seq1, seq2]
+
+    dcur.execute("SHOW SEQUENCES IN ACCOUNT")
+    assert dcur.fetchall() == [seq1, seq2]
+
+
 def test_show_procedures(dcur: snowflake.connector.cursor.SnowflakeCursor):
     dcur.execute("show procedures")
     dcur.fetchall()

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -544,10 +544,10 @@ def test_show_sequences(dcur: snowflake.connector.cursor.SnowflakeCursor):
     assert dcur.fetchall() == [seq2]
 
     dcur.execute("SHOW SEQUENCES IN DATABASE db1")
-    assert sorted(dcur.fetchall(), key=lambda row: row["name"]) == [seq1, seq2]
+    assert sorted(cast(list[dict], dcur.fetchall()), key=lambda row: row["name"]) == [seq1, seq2]
 
     dcur.execute("SHOW SEQUENCES IN ACCOUNT")
-    assert sorted(dcur.fetchall(), key=lambda row: row["name"]) == [seq1, seq2]
+    assert sorted(cast(list[dict], dcur.fetchall()), key=lambda row: row["name"]) == [seq1, seq2]
 
 
 def test_show_procedures(dcur: snowflake.connector.cursor.SnowflakeCursor):


### PR DESCRIPTION
Second of the #416 items.

`SHOW SEQUENCES` wasn't handled, so it fell through to duckdb:

```
'SHOW SEQUENCES IN SCHEMA "SCHEMA1"' ProgrammingError 002003 (42S02):
Catalog Error: Table with name SEQUENCES does not exist!
```

Flyway runs it while checking whether a schema is empty, before it creates its history table.

Backed by `duckdb_sequences()`, which already has what's needed since `CREATE SEQUENCE` passes through to duckdb. Follows `show_stages` for scope resolution, so `IN SCHEMA`, `IN DATABASE` and `IN ACCOUNT` work along with the default of current database + schema.

On the columns: the [SHOW SEQUENCES docs](https://docs.snowflake.com/en/sql-reference/sql/show-sequences) don't list the output, and I couldn't capture a real one because the account I have access to has no sequences. So these follow the shape of the other `_fs_show_*` views here, and I checked what the consumer reads: Flyway sends `SHOW <TYPE>S IN SCHEMA <schema>` and maps rows off the `name` column, then uses it for `DROP <TYPE> <schema>.<name>`. If you have a capture of the real output the column set is easy to adjust.

```
SHOW SEQUENCES                     -> current database and schema only
SHOW SEQUENCES IN SCHEMA schema2   -> that schema
SHOW SEQUENCES IN DATABASE db1     -> both schemas
SHOW SEQUENCES IN ACCOUNT          -> all
```

Full suite passes (`test_cli.py::test_run_server` fails on main here too, unrelated).

With this and #417 applied, Flyway gets past the emptiness check and on to creating `flyway_schema_history`, where it hits a different thing:

```
002043 (02000): Binder Error: Type 'TIMESTAMP WITH TIME ZONE' does not take any type parameters
LINE 1: ... "installed_on" TIMESTAMPTZ(9) NOT NULL DEFAULT CURRENT_TIMESTAMP ...
```

It writes `TIMESTAMP_LTZ(9)`, which transpiles to `TIMESTAMPTZ(9)`, and duckdb won't take a precision there. I'll add that to #416 as the next item.
