### PR TITLE
feat: support SHOW PARAMETERS with a basic set

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -351,6 +351,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.show_databases)
             .transform(transforms.show_functions)
             .transform(transforms.show_procedures)
+            .transform(lambda e: transforms.show_parameters(e, self._conn._autocommit))
             .transform(transforms.show_warehouses)
             .transform(lambda e: transforms.show_schemas(e, self._conn.database))
             .transform(lambda e: transforms.show_tables_etc(e, self._conn.database, self._conn.schema))

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -11,6 +11,7 @@ from fakesnow.transforms.show import (
     show_databases as show_databases,
     show_functions as show_functions,
     show_keys as show_keys,
+    show_parameters as show_parameters,
     show_procedures as show_procedures,
     show_schemas as show_schemas,
     show_sequences as show_sequences,

--- a/fakesnow/transforms/show.py
+++ b/fakesnow/transforms/show.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Literal
 
 import sqlglot
@@ -302,6 +303,79 @@ SELECT
     '' as 'external_access_integrations',
 WHERE 0 = 1;
 """
+
+
+# see https://docs.snowflake.com/en/sql-reference/sql/show-parameters
+# only the session parameters fakesnow honours are listed, so the reported values match behaviour.
+SHOW_PARAMETERS: list[tuple[str, str, str, str]] = [
+    (
+        "AUTOCOMMIT",
+        "true",
+        "true",
+        "The autocommit property determines whether a DML statement, when executed without an active "
+        "transaction, is automatically committed after the statement successfully completes.",
+    ),
+    (
+        "QUOTED_IDENTIFIERS_IGNORE_CASE",
+        "false",
+        "false",
+        "If true, the case of quoted identifiers is ignored.",
+    ),
+    (
+        "TIMEZONE",
+        "Etc/UTC",
+        "America/Los_Angeles",
+        "time zone, e.g. PST, America/Los_Angeles",
+    ),
+]
+
+# sqlglot parses SHOW PARAMETERS as a Command rather than a Show, so match on the command text.
+_SHOW_PARAMETERS = re.compile(
+    r"^\s*PARAMETERS(?:\s+LIKE\s+'(?P<like>(?:[^']|'')*)')?(?:\s+(?:IN|FOR)\s+.*)?\s*$",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _sql_str(value: str) -> str:
+    return "'" + value.replace("'", "''") + "'"
+
+
+def show_parameters(expression: Expr, autocommit: bool) -> Expr:
+    """Transform SHOW PARAMETERS.
+
+    Scopes (IN SESSION, IN ACCOUNT, ...) are accepted and ignored, because fakesnow only has
+    session parameters.
+
+    See https://docs.snowflake.com/en/sql-reference/sql/show-parameters
+    """
+    if not (
+        isinstance(expression, exp.Command)
+        and isinstance(expression.this, str)
+        and expression.this.upper() == "SHOW"
+        and isinstance(rest := expression.args.get("expression"), str)
+        and (match := _SHOW_PARAMETERS.match(rest))
+    ):
+        return expression
+
+    selects = []
+    for key, value, default, description in SHOW_PARAMETERS:
+        if key == "AUTOCOMMIT":
+            value = "true" if autocommit else "false"
+        columns = (
+            (key, "key"),
+            (value, "value"),
+            (default, "default"),
+            ("SESSION" if value != default else "", "level"),
+            (description, "description"),
+        )
+        selects.append("SELECT " + ", ".join(f'{_sql_str(v)} as "{c}"' for v, c in columns))
+
+    query = " UNION ALL ".join(selects)
+    if (like := match.group("like")) is not None:
+        # snowflake matches the pattern case-insensitively, with sql wildcards
+        query = f'SELECT * FROM ({query}) WHERE "key" ILIKE {_sql_str(like.replace(chr(39) * 2, chr(39)))}'
+
+    return sqlglot.parse_one(query, read="duckdb")
 
 
 def show_procedures(expression: Expr) -> Expr:

--- a/tests/test_show.py
+++ b/tests/test_show.py
@@ -550,6 +550,67 @@ def test_show_sequences(dcur: snowflake.connector.cursor.SnowflakeCursor):
     assert sorted(cast(list[dict], dcur.fetchall()), key=lambda row: row["name"]) == [seq1, seq2]
 
 
+def test_show_parameters(dcur: snowflake.connector.cursor.SnowflakeCursor):
+    autocommit = {
+        "key": "AUTOCOMMIT",
+        "value": "true",
+        "default": "true",
+        "level": "",
+        "description": "The autocommit property determines whether a DML statement, when executed without an "
+        "active transaction, is automatically committed after the statement successfully completes.",
+    }
+    quoted_identifiers = {
+        "key": "QUOTED_IDENTIFIERS_IGNORE_CASE",
+        "value": "false",
+        "default": "false",
+        "level": "",
+        "description": "If true, the case of quoted identifiers is ignored.",
+    }
+    timezone = {
+        "key": "TIMEZONE",
+        "value": "Etc/UTC",
+        "default": "America/Los_Angeles",
+        "level": "SESSION",
+        "description": "time zone, e.g. PST, America/Los_Angeles",
+    }
+
+    dcur.execute("SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE'")
+    assert dcur.fetchall() == [quoted_identifiers]
+    assert [r.name for r in dcur.description] == ["key", "value", "default", "level", "description"]
+
+    # the pattern is case-insensitive and takes sql wildcards
+    dcur.execute("SHOW PARAMETERS LIKE 'quoted%'")
+    assert dcur.fetchall() == [quoted_identifiers]
+
+    dcur.execute("SHOW PARAMETERS LIKE 'NOT_A_PARAMETER'")
+    assert dcur.fetchall() == []
+
+    dcur.execute("SHOW PARAMETERS")
+    assert dcur.fetchall() == [autocommit, quoted_identifiers, timezone]
+
+    # a scope is accepted and ignored, fakesnow only has session parameters
+    dcur.execute("SHOW PARAMETERS IN SESSION")
+    assert dcur.fetchall() == [autocommit, quoted_identifiers, timezone]
+
+
+def test_show_parameters_autocommit_off(_fakesnow: None):
+    with (
+        snowflake.connector.connect(database="db1", schema="schema1", autocommit=False) as conn,
+        conn.cursor(snowflake.connector.cursor.DictCursor) as dcur,
+    ):
+        dcur.execute("SHOW PARAMETERS LIKE 'AUTOCOMMIT'")
+        assert dcur.fetchall() == [
+            {
+                "key": "AUTOCOMMIT",
+                "value": "false",
+                "default": "true",
+                "level": "SESSION",
+                "description": "The autocommit property determines whether a DML statement, when executed without "
+                "an active transaction, is automatically committed after the statement successfully completes.",
+            }
+        ]
+
+
 def test_show_procedures(dcur: snowflake.connector.cursor.SnowflakeCursor):
     dcur.execute("show procedures")
     dcur.fetchall()


### PR DESCRIPTION
Last of the #416 items.

`SHOW PARAMETERS` wasn't handled:

```
"SHOW PARAMETERS LIKE 'QUOTED_IDENTIFIERS_IGNORE_CASE'" ProgrammingError 001003 (42000):
Parser Error: syntax error at or near "LIKE"
```

Flyway asks for `QUOTED_IDENTIFIERS_IGNORE_CASE` while setting up the connection. It carries on when the query fails, so this one was never blocking, but it does put an error in the log on every connect.

sqlglot parses `SHOW PARAMETERS` as a `Command` rather than a `Show`, so this matches on the command text instead of following the other `show_*` transforms.

It lists two parameters rather than the full Snowflake set: `QUOTED_IDENTIFIERS_IGNORE_CASE` (false, since `alter_session` only accepts false/unset), and `TIMEZONE` (Etc/UTC, what the server reports). Those are the ones fakesnow honours, so the reported values match what the session actually does. Adding more is a one-line entry each.

```
SHOW PARAMETERS                      2 rows
SHOW PARAMETERS IN SESSION           2 rows, scope accepted and ignored
SHOW PARAMETERS LIKE 'quoted%'       1 row, case-insensitive with sql wildcards
SHOW PARAMETERS LIKE 'NOT_A_PARAM'   0 rows
```

With this and #418, the SHOW statements Flyway issues no longer error. It now gets as far as creating its history table and stops on the `TIMESTAMP_LTZ(9)` item I added to #416.
