### PR TITLE
fix: use of TIMESTAMP_LTZ with precision

### DIFF
--- a/fakesnow/cursor.py
+++ b/fakesnow/cursor.py
@@ -335,6 +335,7 @@ class FakeSnowflakeCursor:
             .transform(transforms.to_variant)
             .transform(transforms.object_construct)
             .transform(transforms.timestamp_ntz)
+            .transform(transforms.timestamp_ltz)
             .transform(transforms.float_to_double)
             .transform(transforms.integer_precision)
             .transform(transforms.extract_text_length)

--- a/fakesnow/transforms/__init__.py
+++ b/fakesnow/transforms/__init__.py
@@ -73,6 +73,7 @@ from fakesnow.transforms.transforms import (
     sha256 as sha256,
     split as split,
     tag as tag,
+    timestamp_ltz as timestamp_ltz,
     timestamp_ntz as timestamp_ntz,
     timestamp_offsets as timestamp_offsets,
     to_date as to_date,

--- a/fakesnow/transforms/transforms.py
+++ b/fakesnow/transforms/transforms.py
@@ -1289,6 +1289,21 @@ def timestamp_ntz(expression: Expr) -> Expr:
     return expression
 
 
+def timestamp_ltz(expression: Expr) -> Expr:
+    """Convert timestamp_ltz (snowflake) to timestamptz (duckdb), dropping any precision.
+
+    Snowflake accepts a precision, eg: TIMESTAMP_LTZ(9), but duckdb's TIMESTAMPTZ takes no type
+    parameters and rejects it with "Type 'TIMESTAMP WITH TIME ZONE' does not take any type
+    parameters". sqlglot drops the precision when generating TIMESTAMP_TZ but keeps it for
+    TIMESTAMP_LTZ, so strip it here.
+    """
+
+    if isinstance(expression, exp.DataType) and expression.this == exp.DataType.Type.TIMESTAMPLTZ:
+        return exp.DataType(this=exp.DataType.Type.TIMESTAMPLTZ)
+
+    return expression
+
+
 def trim_cast_varchar(expression: Expr) -> Expr:
     """Snowflake's TRIM casts input to VARCHAR implicitly."""
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -9,6 +9,7 @@ import tempfile
 from decimal import Decimal
 
 import pytest
+import pytz
 import snowflake.connector
 import snowflake.connector.cursor
 from snowflake.connector.errors import ProgrammingError
@@ -626,6 +627,15 @@ def test_unquoted_identifiers_are_upper_cased(dcur: snowflake.connector.cursor.S
     assert dcur.fetchall() == [
         {"FIRST_NAME": "Jenny", "FNAME": "Jenny"},
     ]
+
+
+def test_timestamp_ltz_with_precision(cur: snowflake.connector.cursor.SnowflakeCursor):
+    # snowflake accepts a precision on TIMESTAMP_LTZ, duckdb's TIMESTAMPTZ does not
+    cur.execute("CREATE TABLE example (ts TIMESTAMP_LTZ(9))")
+    cur.execute("INSERT INTO example VALUES ('2026-09-13 01:02:03+09:00')")
+
+    cur.execute("SELECT ts FROM example")
+    assert cur.fetchall() == [(datetime.datetime(2026, 9, 12, 16, 2, 3, tzinfo=pytz.utc),)]
 
 
 def test_use_role_and_warehouse(cur: snowflake.connector.cursor.SnowflakeCursor):

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -42,6 +42,7 @@ from fakesnow.transforms import (
     show_tables_etc,
     split,
     tag,
+    timestamp_ltz,
     timestamp_ntz,
     to_date,
     to_decimal,
@@ -827,6 +828,22 @@ def test_timestamp_ntz_ns() -> None:
         .transform(timestamp_ntz)
         .sql(dialect="duckdb")
         == "CREATE TABLE table1 (ts TIMESTAMP)"
+    )
+
+
+def test_timestamp_ltz_precision() -> None:
+    # duckdb's TIMESTAMPTZ takes no type parameters, so the snowflake precision is dropped
+    assert (
+        sqlglot.parse_one("CREATE TABLE table1(ts TIMESTAMP_LTZ(9))", read="snowflake")
+        .transform(timestamp_ltz)
+        .sql(dialect="duckdb")
+        == "CREATE TABLE table1 (ts TIMESTAMPTZ)"
+    )
+    assert (
+        sqlglot.parse_one("CREATE TABLE table1(ts TIMESTAMP_LTZ)", read="snowflake")
+        .transform(timestamp_ltz)
+        .sql(dialect="duckdb")
+        == "CREATE TABLE table1 (ts TIMESTAMPTZ)"
     )
 
 


### PR DESCRIPTION
Fifth item from #416.

`TIMESTAMP_LTZ(9)` fails because duckdb's `TIMESTAMPTZ` takes no type parameters:

```
CREATE TABLE example (ts TIMESTAMP_LTZ(9))
002043 (02000): Binder Error: Type 'TIMESTAMP WITH TIME ZONE' does not take any type parameters
```

sqlglot already drops the precision when generating `TIMESTAMP_TZ`, but keeps it for `TIMESTAMP_LTZ`, so `TIMESTAMP_TZ(9)` and `TIMESTAMP_NTZ(9)` both work today and only the LTZ spelling breaks. This mirrors the existing `timestamp_ntz` transform.

Flyway hits this on any migration declaring a precision on a timestamp-with-timezone column.